### PR TITLE
refactor: 长任务的定义方式从 server.tool 改成 server.registerTool

### DIFF
--- a/packages/doc-vanilla/src/nextServer.ts
+++ b/packages/doc-vanilla/src/nextServer.ts
@@ -131,17 +131,20 @@ export const createConsoleServer = async () => {
   })
 
   // 长任务工具
-  server.tool(
-    'long-task',
+  server.registerTool(
     'long-task',
     {
-      steps: z.number().describe('任务步骤')
+      title: 'long-task',
+      inputSchema: {
+        steps: z.number().describe('任务步骤')
+      }
     },
     async ({ steps }, { sendNotification, _meta, signal, requestId }) => {
       for (let i = 0; i < steps; i++) {
+        // progressToken 是一个从0开始自增的数字，每次调用工具，progressToken 都会自增1
         const progressToken = _meta?.progressToken
         console.log('progressToken', progressToken)
-        if (progressToken) {
+        if (progressToken || progressToken === 0) {
           await sendNotification({
             method: 'notifications/progress',
             params: {


### PR DESCRIPTION
主要更新：
- server.tool 改成 server.registerTool
- 修复首次调用工具，progressToken 为0，导致没有正确执行长任务的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the configuration and registration method for the "long-task" tool to improve clarity and consistency.
  * Improved handling of progress updates to ensure accurate tracking, even when progress starts at zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->