### PR TITLE
feat: 增加普通任务的终止demo

### DIFF
--- a/packages/doc-vanilla/index.html
+++ b/packages/doc-vanilla/index.html
@@ -26,6 +26,8 @@
           <button id="call-tool">call Tool</button>
           <button id="call-long-task">Call Long Task</button>
           <button id="abort-task">Abort Task</button>
+          <button id="call-normal-task">Call Normal Task</button>
+          <button id="abort-normal-task">Abort Normal Task</button>
           <button id="subscribe-resource">Subscribe Resource</button>
           <button id="unsubscribe-resource">Unsubscribe Resource</button>
           <button id="read-resource">Read Resource</button>

--- a/packages/doc-vanilla/src/nextClient.ts
+++ b/packages/doc-vanilla/src/nextClient.ts
@@ -112,7 +112,7 @@ export const createConsoleClient = async () => {
   const normalTaskButton = document.getElementById('call-normal-task')
   normalTaskButton?.addEventListener('click', async () => {
     // 任务 promise
-    const promise = await client.callTool({ name: 'normal-task', arguments: { value: '一个随便的参数' } }, CallToolResultSchema, {
+    const promise = await client.callTool({ name: 'normal-task' }, CallToolResultSchema, {
       signal: controllerNormalTask.signal,
     })
     console.log('normal-task result', promise)

--- a/packages/doc-vanilla/src/nextClient.ts
+++ b/packages/doc-vanilla/src/nextClient.ts
@@ -83,16 +83,9 @@ export const createConsoleClient = async () => {
 
   // 调用长任务，并且可以随时取消长任务
   const controller = new AbortController() // 每次调用生成独立 controller
-  let requestId = ''
 
   // abort 方法，取消本次任务
   const abort = async (reason?: string) => {
-    if (requestId) {
-      await client.notification({
-        method: 'notifications/cancelled',
-        params: { requestId, reason, forward: true } // forward: true 告诉代理需要转发这条终止消息
-      })
-    }
     return controller.abort(reason)
   }
 
@@ -103,7 +96,6 @@ export const createConsoleClient = async () => {
       signal: controller.signal,
       onprogress: (progress) => {
         console.log('progress', progress)
-        requestId = progress.requestId as string
       }
     })
     console.log('result', promise)
@@ -112,6 +104,23 @@ export const createConsoleClient = async () => {
   const abortButton = document.getElementById('abort-task')
   abortButton?.addEventListener('click', async () => {
     await abort('用户取消')
+  })
+
+  // 普通任务的终止只需要初始化浏览器原生的 AbortController，传给 signal 参数即可
+  const controllerNormalTask = new AbortController()
+
+  const normalTaskButton = document.getElementById('call-normal-task')
+  normalTaskButton?.addEventListener('click', async () => {
+    // 任务 promise
+    const promise = await client.callTool({ name: 'normal-task', arguments: { value: '一个随便的参数' } }, CallToolResultSchema, {
+      signal: controllerNormalTask.signal,
+    })
+    console.log('normal-task result', promise)
+  })
+
+  const abortNormalButton = document.getElementById('abort-normal-task')
+  abortNormalButton?.addEventListener('click', async () => {
+    await controllerNormalTask.abort('用户取消普通任务')
   })
 
   const subscribeResourceButton = document.getElementById('subscribe-resource')

--- a/packages/doc-vanilla/src/nextServer.ts
+++ b/packages/doc-vanilla/src/nextServer.ts
@@ -168,6 +168,31 @@ export const createConsoleServer = async () => {
     }
   )
 
+  server.registerTool(
+    'normal-task',
+    {
+      title: '普通任务的终止，只需要加上 signal 即可',
+      inputSchema: {
+        value: z.string()
+      }
+    },
+    async ({ value }, { signal }) => {
+      for (let i = 0; i < 10; i++) {
+        console.log('普通任务正在进行中...', i);
+
+        if (signal.aborted) {
+          server.server.sendLoggingMessage({ level: 'error', data: '服务端 - 普通任务已终止' })
+          break
+        }
+
+        await sleep(1000)
+      }
+
+      await server.server.sendLoggingMessage({ level: 'info', data: '服务端 - 普通任务已结束' })
+      return { content: [{ type: 'text', text: '普通任务完成！'}] }
+    }
+  )
+
   // 更新工具
   updateToolButton?.addEventListener('click', async () => {
     tool.update({

--- a/packages/doc-vanilla/src/nextServer.ts
+++ b/packages/doc-vanilla/src/nextServer.ts
@@ -172,11 +172,8 @@ export const createConsoleServer = async () => {
     'normal-task',
     {
       title: '普通任务的终止，只需要加上 signal 即可',
-      inputSchema: {
-        value: z.string()
-      }
     },
-    async ({ value }, { signal }) => {
+    async ({ signal }) => {
       for (let i = 0; i < 10; i++) {
         console.log('普通任务正在进行中...', i);
 


### PR DESCRIPTION
主要变更：
- 增加普通任务的终止操作，只用到 signal 参数，任务的终止不是长任务工具专属的，所有 MCP 工具的任务都可以终止
- 移除普通 Client 场景下的 requestId，普通 Client 场景下可以直接使用 controller.abort 终止任务，不需要传入 requestId

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Call Normal Task" and "Abort Normal Task" buttons to the interface for task management.
  * Introduced a new "normal task" that runs with progress logging and supports cancellation.
* **Improvements**
  * Streamlined task cancellation process for both long and normal tasks, enhancing responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->