### PR TITLE
feat: 支持工具调用链式显示

### DIFF
--- a/packages/doc-ai/components.d.ts
+++ b/packages/doc-ai/components.d.ts
@@ -7,6 +7,7 @@ export {}
 
 declare module 'vue' {
   export interface GlobalComponents {
+    ReactiveMarkdown: typeof import('./src/components/ReactiveMarkdown.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     TinyBaseSelect: typeof import('@opentiny/vue-base-select')['default']

--- a/packages/doc-ai/package.json
+++ b/packages/doc-ai/package.json
@@ -10,9 +10,9 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.0",
-    "@opentiny/tiny-robot": "0.3.0-alpha.2",
-    "@opentiny/tiny-robot-kit": "0.3.0-alpha.2",
-    "@opentiny/tiny-robot-svgs": "0.3.0-alpha.2",
+    "@opentiny/tiny-robot": "0.3.0-alpha.3",
+    "@opentiny/tiny-robot-kit": "0.3.0-alpha.3",
+    "@opentiny/tiny-robot-svgs": "0.3.0-alpha.3",
     "@opentiny/icons": "^0.1.3",
     "@opentiny/next": "^0.2.1",
     "@opentiny/tiny-vue-mcp": "^0.0.2",

--- a/packages/doc-ai/package.json
+++ b/packages/doc-ai/package.json
@@ -10,9 +10,9 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.0",
-    "@opentiny/tiny-robot": "0.2.1",
-    "@opentiny/tiny-robot-kit": "0.2.1",
-    "@opentiny/tiny-robot-svgs": "0.2.1",
+    "@opentiny/tiny-robot": "0.3.0-alpha.2",
+    "@opentiny/tiny-robot-kit": "0.3.0-alpha.2",
+    "@opentiny/tiny-robot-svgs": "0.3.0-alpha.2",
     "@opentiny/icons": "^0.1.3",
     "@opentiny/next": "^0.2.1",
     "@opentiny/tiny-vue-mcp": "^0.0.2",

--- a/packages/doc-ai/src/App.vue
+++ b/packages/doc-ai/src/App.vue
@@ -1,5 +1,9 @@
 <template>
   <div class="app-container">
+    <div class="keep-icon-and-hideme">
+      <IconAi />
+      <IconUser />
+    </div>
     <!-- 主体内容区域 -->
     <div class="main-content">
       <router-view />
@@ -16,7 +20,7 @@
 import '@opentiny/icons/style/all.css'
 import TinyRobotChat from './components/tiny-robot-chat.vue'
 import { showTinyRobot } from './composable/utils'
-import { IconAi } from '@opentiny/tiny-robot-svgs'
+import { IconAi, IconUser } from '@opentiny/tiny-robot-svgs'
 </script>
 
 <style scoped>
@@ -27,6 +31,13 @@ import { IconAi } from '@opentiny/tiny-robot-svgs'
   align-items: center;
   padding: 10px 20px;
   background-color: #f5f5f5;
+}
+
+/* 隐藏区域，保留svg永远可见 */
+.keep-icon-and-hideme,
+.keep-icon-and-hideme svg {
+  width: 0;
+  height: 0;
 }
 
 .qr-code {

--- a/packages/doc-ai/src/components/ReactiveMarkdown.vue
+++ b/packages/doc-ai/src/components/ReactiveMarkdown.vue
@@ -1,0 +1,9 @@
+<template>
+<div v-html="markdown"></div></template>
+<script setup lang="ts">
+import { BubbleMarkdownMessageRenderer } from '@opentiny/tiny-robot';
+import { computed }from 'vue';
+const props = defineProps<{content:string}>()
+const markdownRenderer = new BubbleMarkdownMessageRenderer()
+const markdown = computed(()=> markdownRenderer.md.render(props.content))
+</script>

--- a/packages/doc-ai/src/components/tiny-robot-chat.vue
+++ b/packages/doc-ai/src/components/tiny-robot-chat.vue
@@ -2,26 +2,30 @@
   <!-- mcp-robot弹窗 -->
 
   <tr-container v-model:show="showTinyRobot" v-model:fullscreen="fullscreen">
-    <div v-if="messages.length === 0">
-      <tr-welcome title="智能助手" description="您好，我是Opentiny AI智能助手" :icon="welcomeIcon">
-        <template #footer>
-          <div class="welcome-footer"></div>
-        </template>
-      </tr-welcome>
-      <tr-prompts
-        :items="promptItems"
-        :wrap="true"
-        item-class="prompt-item"
-        class="tiny-prompts"
-        @item-click="handlePromptItemClick"
-      ></tr-prompts>
-    </div>
-    <tr-bubble-list
-      v-else
-      :items="messages.filter((item: any) => item.role !== 'system' && item.role !== 'tool')"
-      :roles="roles"
-      auto-scroll
-    ></tr-bubble-list>
+    <tr-bubble-provider :message-renderers="messageRenderers">
+      <div v-if="messages.length === 0">
+        <tr-welcome title="智能助手" description="您好，我是Opentiny AI智能助手" :icon="welcomeIcon">
+          <template #footer>
+            <div class="welcome-footer"></div>
+          </template>
+        </tr-welcome>
+        <tr-prompts
+          :items="promptItems"
+          :wrap="true"
+          item-class="prompt-item"
+          class="tiny-prompts"
+          @item-click="handlePromptItemClick"
+        ></tr-prompts>
+      </div>
+      <tr-bubble-list
+        v-else
+        :items="messages.filter((item: any) => item.role !== 'system' && item.role !== 'tool')"
+        :roles="roles"
+        auto-scroll
+      >
+      </tr-bubble-list>
+    </tr-bubble-provider>
+
     <template #footer>
       <div class="chat-input">
         <TrSuggestionPills :items="suggestionPillItems" @item-click="handleSuggestionPillItemClick" /><br />
@@ -30,7 +34,7 @@
           mode="single"
           v-model="inputMessage"
           :placeholder="GeneratingStatus.includes(messageState.status) ? '正在思考中...' : '请输入您的问题'"
-          :clearable="true"
+          :clearable="!!inputMessage"
           :loading="GeneratingStatus.includes(messageState.status)"
           :showWordLimit="true"
           :maxLength="1000"
@@ -46,10 +50,31 @@
 </template>
 
 <script setup lang="ts">
-import { TrBubbleList, TrContainer, TrPrompts, TrSender, TrWelcome, TrSuggestionPills } from '@opentiny/tiny-robot'
+import {
+  TrBubbleList,
+  TrContainer,
+  TrPrompts,
+  TrSender,
+  TrWelcome,
+  TrSuggestionPills,
+  TrBubbleProvider,
+  BubbleMarkdownMessageRenderer,
+  BubbleChainMessageRenderer
+} from '@opentiny/tiny-robot'
 import { GeneratingStatus } from '@opentiny/tiny-robot-kit'
 import { useTinyRobot } from '../composable/useTinyRobot'
 import { showTinyRobot } from '../composable/utils'
+
+const mdRenderer = new BubbleMarkdownMessageRenderer()
+const messageRenderers = {
+  markdown: mdRenderer,
+  chain: {
+    component: BubbleChainMessageRenderer,
+    defaultProps: {
+      contentRenderer: (content: string) => mdRenderer.md.render(content)
+    }
+  }
+}
 
 const {
   fullscreen,
@@ -120,5 +145,11 @@ const {
   width: 300px;
   height: 600px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.04);
+}
+</style>
+
+<style>
+.tr-chain-item__body .tr-chain-item__content {
+  word-break: break-all;
 }
 </style>

--- a/packages/doc-ai/src/composable/AgentModelProvider.ts
+++ b/packages/doc-ai/src/composable/AgentModelProvider.ts
@@ -4,6 +4,7 @@ import type { ChatCompletionRequest } from '@opentiny/tiny-robot-kit'
 import type { StreamHandler } from '@opentiny/tiny-robot-kit'
 import { BaseModelProvider } from '@opentiny/tiny-robot-kit'
 import type { AIModelConfig } from '@opentiny/tiny-robot-kit'
+import { reactive, ref } from 'vue'
 
 // 创建nextClient
 const nextClient = createClient(
@@ -24,6 +25,35 @@ nextClient.use(createInMemoryTransport())
 nextClient.connectTransport()
 
 let messageIndex = 0
+let lastContent: any
+let lastToolCall: any
+
+const onToolCallChain = (extra: any, handler: StreamHandler) => {
+  lastContent = null
+  const { delta } = extra
+  const infoItem = reactive({
+    id: delta.toolCall.id,
+    title: delta.toolCall.function.name,
+    content: delta.toolCall.callToolContent
+      ? '工具调用结果：' + delta.toolCall.callToolContent
+      : `\n正在调用工具${delta.toolCall.function.name}`
+  })
+  if (!lastToolCall || lastToolCall.items?.[0]?.id !== infoItem.id) {
+    lastToolCall = {
+      type: 'chain',
+      items: [infoItem]
+    }
+
+    handler.onMessage(lastToolCall)
+  } else {
+    const find = lastToolCall.items.find((item: any) => item.id === infoItem.id)
+    if (find) {
+      find.content = infoItem.content
+    } else {
+      lastToolCall.items.push(infoItem)
+    }
+  }
+}
 
 const mcpHost = createMCPHost({
   llmOption: {
@@ -49,6 +79,7 @@ export class AgentModelProvider extends BaseModelProvider {
   async chatStream(request: ChatCompletionRequest, handler: StreamHandler): Promise<void> {
     // 验证请求的messages属性，必须是数组，且每个消息必须有role\content属性
     const lastMessage = request.messages[request.messages.length - 1].content
+    lastToolCall = null
     mcpHost.chatStream(lastMessage, {
       onData: (data: any) => {
         const resData = {
@@ -64,7 +95,21 @@ export class AgentModelProvider extends BaseModelProvider {
           object: '',
           model: ''
         }
-        handler.onData(resData)
+        if (data.delta.role === 'tool') {
+          onToolCallChain(data, handler)
+        } else {
+          if (!lastContent) {
+            lastContent = {
+              type: 'text',
+              content: ref(data.delta.content)
+            }
+            handler.onMessage(lastContent)
+          } else {
+            lastContent.content.value += data.delta.content
+          }
+
+          handler.onData(resData)
+        }
       },
       onDone: () => {
         handler.onDone()

--- a/packages/doc-ai/src/composable/useTinyRobot.ts
+++ b/packages/doc-ai/src/composable/useTinyRobot.ts
@@ -32,7 +32,6 @@ export const useTinyRobot = () => {
 
   const { messageManager } = useConversation({ client })
   const { messageState, inputMessage, sendMessage, abortRequest, messages } = messageManager
-  window.zzc = messageManager
 
   const roles = {
     assistant: {

--- a/packages/doc-ai/src/composable/useTinyRobot.ts
+++ b/packages/doc-ai/src/composable/useTinyRobot.ts
@@ -3,6 +3,8 @@ import { IconAi, IconUser } from '@opentiny/tiny-robot-svgs'
 import { h, nextTick, onMounted, ref, watch } from 'vue'
 import type { SuggestionItem } from '@opentiny/tiny-robot'
 import { AgentModelProvider } from './AgentModelProvider'
+import { BubbleMarkdownMessageRenderer } from '@opentiny/tiny-robot'
+const mdRenderer = new BubbleMarkdownMessageRenderer()
 
 export const useTinyRobot = () => {
   const client = new AIClient({
@@ -30,18 +32,21 @@ export const useTinyRobot = () => {
 
   const { messageManager } = useConversation({ client })
   const { messageState, inputMessage, sendMessage, abortRequest, messages } = messageManager
+  window.zzc = messageManager
 
   const roles = {
     assistant: {
       type: 'markdown',
       placement: 'start',
       avatar: aiAvatar,
-      maxWidth: '80%'
+      maxWidth: '80%',
+      contentRenderer: mdRenderer
     },
     user: {
       placement: 'end',
       avatar: userAvatar,
-      maxWidth: '80%'
+      maxWidth: '80%',
+      contentRenderer: mdRenderer
     }
   }
 

--- a/packages/sdk/src/mcp-host/core/index.ts
+++ b/packages/sdk/src/mcp-host/core/index.ts
@@ -135,7 +135,7 @@ export class MCPHost {
           handler.onData({
             delta: {
               role: Role.ASSISTANT,
-              content: `\n正在调用工具：${toolCall.function.name}\n参数：`
+              content: `\n\n正在调用工具：${toolCall.function.name}\n\n参数：`
             }
           })
         }
@@ -161,7 +161,7 @@ export class MCPHost {
     handler.onData({
       delta: {
         role: 'assistant',
-        content: `\n`
+        content: `\n\n`
       }
     })
     // 返回所有 tool_call 组成的数组，以及 content
@@ -294,9 +294,11 @@ export class MCPHost {
     }
 
     this.iteration = MAX_ITERATION
-    this.processSteamToolCallsAndResponses(handler).catch((error) => {
+    await this.processSteamToolCallsAndResponses(handler).catch((error) => {
       console.error('Chat failed:', error)
     })
+
+    return 'ok'
   }
 
   /**
@@ -338,7 +340,6 @@ export class MCPHost {
           this.iteration = 0
         }
       }
-
       handler.onDone()
     } catch (error) {
       console.error('Chat iteration failed:', error)

--- a/packages/sdk/src/mcp-host/core/index.ts
+++ b/packages/sdk/src/mcp-host/core/index.ts
@@ -121,28 +121,21 @@ export class MCPHost {
         if (toolCallDelta.id) {
           lastToolCallId = toolCallDelta.id
           // 新的 tool_call
-          toolCallMap.set(lastToolCallId, {
+
+          const toolCall = {
             id: toolCallDelta.id,
             type: toolCallDelta.type,
             function: {
               name: toolCallDelta.function?.name || '',
               arguments: toolCallDelta.function?.arguments || ''
             }
-          })
-
-          const functionName = toolCallDelta.function?.name || ''
-
-          handler.onData({
-            delta: {
-              role: 'assistant',
-              content: `调用工具：${functionName}`
-            }
-          })
+          }
+          toolCallMap.set(lastToolCallId, toolCall)
 
           handler.onData({
             delta: {
-              role: 'assistant',
-              content: `\n\n参数：`
+              role: Role.ASSISTANT,
+              content: `\n正在调用工具：${toolCall.function.name}\n参数：`
             }
           })
         }
@@ -156,7 +149,7 @@ export class MCPHost {
             prev.function.arguments += toolCallDelta.function?.arguments || ''
             handler.onData({
               delta: {
-                role: 'assistant',
+                role: Role.ASSISTANT,
                 content: `${toolCallDelta.function?.arguments}`
               }
             })
@@ -168,10 +161,9 @@ export class MCPHost {
     handler.onData({
       delta: {
         role: 'assistant',
-        content: `\n\n`
+        content: `\n`
       }
     })
-    handler.onDone()
     // 返回所有 tool_call 组成的数组，以及 content
     return [Array.from(toolCallMap.values()), content]
   }
@@ -181,7 +173,10 @@ export class MCPHost {
    * @param toolCalls 工具调用请求列表
    * @returns 工具调用结果和消息
    */
-  protected async callTools(toolCalls: ToolCall[]): Promise<{ toolResults: ToolResults; toolCallMessages: Message[] }> {
+  protected async callTools(
+    toolCalls: ToolCall[],
+    handler: StreamHandler
+  ): Promise<{ toolResults: ToolResults; toolCallMessages: Message[] }> {
     try {
       const toolResults: ToolResults = []
       const toolCallMessages: Message[] = []
@@ -206,6 +201,21 @@ export class MCPHost {
           console.error(`Failed to parse tool arguments for ${toolName}:`, _error)
           toolArgs = {}
         }
+        const beforeToolCall = {
+          id: toolCall.id,
+          type: toolCall.type,
+          function: {
+            name: toolCall.function?.name || '',
+            arguments: toolCall.function?.arguments || ''
+          }
+        }
+
+        handler.onData({
+          delta: {
+            role: Role.TOOL,
+            toolCall: beforeToolCall
+          }
+        })
 
         // 真正调用工具
         const callToolResult = (await client.callTool({
@@ -218,6 +228,23 @@ export class MCPHost {
           tool_call_id: toolCall.id,
           content: callToolContent
         }
+
+        const toolCallMessage = {
+          id: toolCall.id,
+          type: toolCall.type,
+          callToolContent: callToolContent,
+          function: {
+            name: toolCall.function?.name || '',
+            arguments: toolCall.function?.arguments || ''
+          }
+        }
+
+        handler.onData({
+          delta: {
+            role: Role.TOOL,
+            toolCall: toolCallMessage
+          }
+        })
 
         toolCallMessages.push(message)
         toolResults.push({
@@ -286,6 +313,7 @@ export class MCPHost {
         // 解析工具调用和最终回复
         const [tool_calls, content] = await this.parseToolCalls(response as any, handler)
 
+        // 如果有工具调用
         if (tool_calls.length) {
           // 构造带 tool_calls 的 assistant 消息，符合 OpenAI Function Calling 协议
           const assistantMsg = {
@@ -300,7 +328,7 @@ export class MCPHost {
           // 1. 先把带 tool_calls 的 assistant 消息 push 进去
           this.messages.push(assistantMsg)
           // 2. 再 push tool 消息
-          const { toolResults, toolCallMessages } = await this.callTools(tool_calls)
+          const { toolResults, toolCallMessages } = await this.callTools(tool_calls, handler)
           toolsCallResults.push(...toolResults)
           toolCallMessages.forEach((m) => this.messages.push(m))
           this.iteration--
@@ -310,6 +338,8 @@ export class MCPHost {
           this.iteration = 0
         }
       }
+
+      handler.onDone()
     } catch (error) {
       console.error('Chat iteration failed:', error)
       throw error

--- a/packages/sdk/src/type.ts
+++ b/packages/sdk/src/type.ts
@@ -284,6 +284,7 @@ export interface ChatCreatePromptArgs {
 export interface ChatCompletionStreamResponseDelta {
   content?: string
   role?: MessageRole
+  toolCall?: ToolCall
 }
 
 /**
@@ -322,5 +323,6 @@ export interface AIAdapterError {
 export interface StreamHandler {
   onData: (data: ChatCompletionStreamResponse) => void
   onError: (error: AIAdapterError) => void
+  onMessage?: (msgObj: { type: string; [extra: string]: unknown }) => void
   onDone: () => void
 }


### PR DESCRIPTION
遗留问题：tiny-robot的message中的type=markdown就无法流式输出
效果如下：
<img width="1868" height="484" alt="image" src="https://github.com/user-attachments/assets/9d71a668-e599-42fd-80cd-1d80eb8bdd8d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced chat experience with improved rendering for markdown and chain messages.
  * Added streaming updates and richer feedback for tool calls during chat interactions.
  * Introduced a new reactive markdown component for dynamic content rendering.

* **Bug Fixes**
  * Improved word wrapping for chain message content to enhance readability.

* **Refactor**
  * Unified and streamlined message handling for tool calls and streaming data in chat and backend logic.

* **Chores**
  * Updated dependencies to newer pre-release versions for improved stability and features.
  * Added hidden SVG icon elements to ensure icon availability without visual impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->