### PR TITLE
fix: support MCP Inspector auto set logging level

### DIFF
--- a/packages/next-sdk/WebMcpServer.ts
+++ b/packages/next-sdk/WebMcpServer.ts
@@ -88,6 +88,10 @@ export class WebMcpServer {
     this.server.server.onerror = (error: Error) => {
       this.onerror?.(error)
     }
+
+    this.server.server.setRequestHandler(SetLevelRequestSchema, async () => {
+      return {}
+    })
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MCP server now gracefully handles log-level change requests by default, returning an empty response when no custom handler is configured, improving compatibility and preventing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->