### PR TITLE
feat: Added WebMCP demo page using CDN mode

### DIFF
--- a/docs/public/WebMCP.html
+++ b/docs/public/WebMCP.html
@@ -1,0 +1,86 @@
+<html>
+  <head>
+    <!-- 导入 NEXT SDK -->
+    <script src="https://unpkg.com/@opentiny/next-sdk@0.1.1-alpha.2/dist/index.umd.js"></script>
+    <meta charset="UTF-8" />
+    <title>WebMCP 示例</title>
+    <script>
+      const { createMessageChannelPairTransport, WebMcpServer, WebMcpClient, ResourceTemplate, z } = WebMCP
+
+      async function connect() {
+        // Create pair MCP transports
+        const [serverTransport, clientTransport] = createMessageChannelPairTransport()
+        // Create an MCP server
+        const server = new WebMcpServer({ name: 'demo-server', version: '1.0.0' })
+
+        // Add an addition tool
+        server.registerTool(
+          'add',
+          {
+            title: 'Addition Tool',
+            description: 'Add two numbers',
+            inputSchema: { a: z.number(), b: z.number() }
+          },
+          async ({ a, b }) => ({
+            content: [{ type: 'text', text: String(a + b) }]
+          })
+        )
+
+        // Add a dynamic greeting resource
+        server.registerResource(
+          'greeting',
+          new ResourceTemplate('greeting://{name}', { list: undefined }),
+          {
+            title: 'Greeting Resource',
+            description: 'Dynamic greeting generator'
+          },
+          async (uri, { name }) => ({
+            contents: [{ uri: uri.href, text: `Hello, ${name}!` }]
+          })
+        )
+
+        // Add a code review prompt
+        server.registerPrompt(
+          'review',
+          {
+            title: 'Code Review',
+            description: 'Review code for best practices and potential issues',
+            argsSchema: { code: z.string() }
+          },
+          ({ code }) => ({
+            messages: [{ role: 'user', content: { type: 'text', text: `code: ${code}` } }]
+          })
+        )
+
+        // Create an MCP Client
+        const client = new WebMcpClient({ name: 'demo-client', version: '1.0.0' })
+
+        // Connect the client and server
+        await server.connect(serverTransport)
+        await client.connect(clientTransport)
+
+        // Client callTool, readResource, and getPrompt
+        console.log(await client.callTool({ name: 'add', arguments: { a: 5, b: 6 } }))
+        console.log(await client.readResource({ uri: 'greeting://John' }))
+        console.log(await client.getPrompt({ name: 'review', arguments: { code: 'x' } }))
+
+        // Connect to the Web Agent server
+        const { transport, sessionId } = await client.connect({
+          url: 'https://agent.opentiny.design/api/v1/webmcp-trial/mcp',
+          agent: true
+        })
+
+        // Display the session ID
+        document.getElementById('sessionId').innerText = sessionId
+
+        window.addEventListener('pagehide', async () => {
+          await transport.terminateSession()
+        })
+      }
+    </script>
+  </head>
+  <body>
+    <button onclick="connect()">Connect Web Agent</button>
+    https://agent.opentiny.design/api/v1/webmcp-trial/mcp?sessionId=<span id="sessionId"></span>
+  </body>
+</html>

--- a/packages/next-sdk/package.json
+++ b/packages/next-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-sdk",
-  "version": "0.1.1-alpha.1",
+  "version": "0.1.1-alpha.2",
   "type": "module",
   "license": "MIT",
   "author": "Chunhui Mo",


### PR DESCRIPTION
feat: 新增WebMCP演示页面使用cdn模式

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive demo page showcasing WebMCP usage: run a local client/server, call a sample tool, read a resource, fetch a prompt, and connect to a Web Agent. Includes a Connect button, session ID display, and auto-termination on page exit.

* **Documentation**
  * Introduced a self-contained HTML example to help users explore WebMCP capabilities directly in the browser.

* **Chores**
  * Bumped SDK version to 0.1.1-alpha.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->