### PR TITLE
fix: Unify the title format and change "OpenTiny Next" to "OpenTiny NEXT"

### DIFF
--- a/packages/next-remoter/src/App.vue
+++ b/packages/next-remoter/src/App.vue
@@ -49,7 +49,7 @@ const sessionId = query.get('sessionId') || ''
 const agentRoot = query.get('agentRoot') || 'https://agent.opentiny.design/api/v1/webmcp-trial/'
 
 // 4、标题
-const title = query.get('title') || 'OpenTiny Next'
+const title = query.get('title') || 'OpenTiny NEXT'
 
 // 5、  定制接收 prompts, suggestion的参数
 const welcomeTitle = query.get('welcome-title')

--- a/packages/next-remoter/src/components/tiny-robot-chat.vue
+++ b/packages/next-remoter/src/components/tiny-robot-chat.vue
@@ -136,7 +136,7 @@ const props = defineProps({
   /** 左上角的标题 */
   title: {
     type: String,
-    default: 'OpenTiny Next'
+    default: 'OpenTiny NEXT'
   },
   /** 语言 en-US、zh-CN */
   locale: {


### PR DESCRIPTION
fix: 统一标题格式，将 "OpenTiny Next" 修改为 "OpenTiny NEXT" 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized the default title capitalization from “OpenTiny Next” to “OpenTiny NEXT” across the UI.
  * Applies when no custom title is provided, ensuring consistent branding in headers and the robot chat component.
  * No functional behavior changed; only visible text updated.
  * Improves visual consistency and readability across views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->