### PR TITLE
feat: Remove the v-console script and rename the tool for getting the date to get-today

### DIFF
--- a/packages/next-remoter/index.html
+++ b/packages/next-remoter/index.html
@@ -4,15 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/svgs/logo-next-no-bg-right.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script src="https://unpkg.com/vconsole/dist/vconsole.min.js"></script>
     <title>OpenTiny NEXT Remoter</title>
   </head>
   <body>
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
-    <script>
-      // VConsole will be exported to `window.VConsole` by default.
-      var vConsole = new window.VConsole()
-    </script>
   </body>
 </html>

--- a/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
+++ b/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
@@ -55,8 +55,8 @@ export class CustomAgentModelProvider extends BaseModelProvider {
       system: this.systemPrompt,
       abortSignal: request.options?.signal,
       tools: {
-        'get-now-date': tool({
-          description: '获取当前日期',
+        'get-today': tool({
+          description: '获取今天的日期',
           inputSchema: z.object({}),
           execute: () => ({
             date: `当前日期: ${dayjs().format('YYYY-M-D')}`


### PR DESCRIPTION
feat: 移除v-console脚本并重命名获取日期的工具为get-today

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the date-retrieval tool to “Get today” with a clearer description; behavior and output remain unchanged.

* **Chores**
  * Removed the VConsole debug integration from the HTML to streamline load and eliminate the in-page debug console.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->