### PR TITLE
feat(next-sdk): update @opentiny/next dependency to 0.3.1 and add WebSocket support in WebMcpClient

### DIFF
--- a/packages/next-sdk/WebMcpClient.ts
+++ b/packages/next-sdk/WebMcpClient.ts
@@ -1,6 +1,7 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { WebSocketClientTransport } from '@modelcontextprotocol/sdk/client/websocket.js'
 import { z, ZodObject, ZodLiteral, ZodType } from 'zod'
 import {
   ElicitRequestSchema,
@@ -18,8 +19,9 @@ import {
   sseOptions,
   streamOptions,
   attemptConnection,
-  createStreamProxy,
   createSseProxy,
+  createStreamProxy,
+  createSocketProxy,
   AuthClientProvider
 } from '@opentiny/next'
 import type {
@@ -60,7 +62,7 @@ export interface ClientConnectOptions {
   token?: string
   sessionId?: string
   authProvider?: AuthClientProvider
-  type?: 'channel' | 'sse'
+  type?: 'channel' | 'sse' | 'stream' | 'socket'
   agent?: boolean
   onError?: (error: Error) => void
   onUnauthorized?: (connect: () => Promise<void>) => Promise<void>
@@ -126,7 +128,11 @@ export class WebMcpClient {
 
       const connectProxy = async () => {
         const { transport, sessionId } =
-          type === 'sse' ? await createSseProxy(proxyOptions) : await createStreamProxy(proxyOptions)
+          type === 'sse'
+            ? await createSseProxy(proxyOptions)
+            : type === 'socket'
+              ? await createSocketProxy(proxyOptions)
+              : await createStreamProxy(proxyOptions)
 
         transport.onerror = async (error: Error) => {
           onError?.(error)
@@ -167,6 +173,12 @@ export class WebMcpClient {
         transport = new SSEClientTransport(endpoint, opts)
         await this.client.connect(transport)
       }
+    }
+
+    if (type === 'socket') {
+      transport = new WebSocketClientTransport(new URL(`${url}?sessionId=${sessionId}&token=${token}`))
+      transport.sessionId = sessionId
+      await this.client.connect(transport)
     }
 
     if (typeof transport === 'undefined') {

--- a/packages/next-sdk/package.json
+++ b/packages/next-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-sdk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "license": "MIT",
   "author": "Chunhui Mo",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.16.0",
-    "@opentiny/next": "^0.3.0",
+    "@opentiny/next": "^0.3.1",
     "@ai-sdk/openai": "^2.0.0",
     "@ai-sdk/deepseek": "^1.0.7",
     "@ai-sdk/provider": "^2.0.0",


### PR DESCRIPTION
feat(next-sdk): 更新 @opentiny/next 依赖至 0.3.1，并在 WebMcpClient 中添加 WebSocket 支持

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebSocket-based connection option (“socket”) alongside existing channel, SSE, and stream options.
  * Enhanced connection logic to automatically choose the appropriate proxy for SSE, socket, or stream.
  * Preserves existing behaviors while adding a WebSocket workflow for improved real-time connectivity.

* **Chores**
  * Bumped package version to 0.1.6.
  * Updated dependency on @opentiny/next to the latest compatible release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->