### PR TITLE
feat(next-remoter): Add visual build support, update configuration to integrate rollup-plugin-visualizer

### DIFF
--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -15,6 +15,7 @@
     "dev": "vite",
     "build": "vite build",
     "build:site": "vite build --config vite.remoter.config.ts",
+    "build:visualizer": "vite build --mode visualizer",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -36,6 +37,7 @@
     "@vitejs/plugin-vue": "^4.5.2",
     "vite-svg-loader": "^5.1.0",
     "@vant/auto-import-resolver": "^1.3.0",
+    "rollup-plugin-visualizer": "^6.0.3",
     "typescript": "^5.2.2",
     "vite": "^5.0.8",
     "vue-tsc": "^1.8.25",

--- a/packages/next-remoter/vite.config.ts
+++ b/packages/next-remoter/vite.config.ts
@@ -7,48 +7,57 @@ import AutoImport from 'unplugin-auto-import/vite'
 import { TinyVueSingleResolver } from '@opentiny/unplugin-tiny-vue'
 import svgLoader from 'vite-svg-loader'
 import { VantResolver } from '@vant/auto-import-resolver'
+import { visualizer } from 'rollup-plugin-visualizer'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [
-    vue(),
-    Components({
-      resolvers: [TinyVueSingleResolver, VantResolver()]
-    }),
-    AutoImport({
-      resolvers: [TinyVueSingleResolver, VantResolver()]
-    }),
-    svgLoader({
-      defaultImport: 'component',
-      svgo: false
-    })
-  ],
-  server: {
-    port: 8087,
-    host: true,
-    proxy: {
-      '/api': {
-        target: 'https://agent.opentiny.design',
-        changeOrigin: true
+export default defineConfig(({ mode }) => {
+  const isVisualizer = mode === 'visualizer'
+  return {
+    plugins: [
+      vue(),
+      Components({
+        resolvers: [TinyVueSingleResolver, VantResolver()]
+      }),
+      AutoImport({
+        resolvers: [TinyVueSingleResolver, VantResolver()]
+      }),
+      svgLoader({
+        defaultImport: 'component',
+        svgo: false
+      }),
+      isVisualizer &&
+        visualizer({
+          open: true,
+          filename: 'stats.html'
+        })
+    ],
+    server: {
+      port: 8087,
+      host: true,
+      proxy: {
+        '/api': {
+          target: 'https://agent.opentiny.design',
+          changeOrigin: true
+        }
       }
-    }
-  },
-  build: {
-    sourcemap: true,
-    minify: false,
-    lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
-      name: 'NextRemoter',
-      formats: ['es', 'cjs', 'umd'],
-      fileName: (format) => `next-remoter.${format}.js`
     },
-    rollupOptions: {
-      external: ['vue'],
-      output: {
-        globals: {
-          vue: 'Vue'
+    build: {
+      sourcemap: true,
+      minify: false,
+      lib: {
+        entry: resolve(__dirname, 'src/index.ts'),
+        name: 'NextRemoter',
+        formats: ['es', 'cjs', 'umd'],
+        fileName: (format) => `next-remoter.${format}.js`
+      },
+      rollupOptions: {
+        external: ['vue'],
+        output: {
+          globals: {
+            vue: 'Vue'
+          }
         }
       }
     }


### PR DESCRIPTION
feat(next-remoter): 添加可视化构建支持，更新配置以集成 rollup-plugin-visualizer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Introduced an opt-in build visualization mode to analyze bundle size and module composition. When used, it generates an interactive stats report that opens automatically for inspection. Standard builds remain unaffected with no changes to app behavior or performance. This tooling supports proactive performance monitoring and helps identify optimization opportunities without impacting end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->