### PR TITLE
fix(remoter): 增加会话历史和切换会话

### DIFF
--- a/packages/next-remoter/src/components/tiny-robot-chat.vue
+++ b/packages/next-remoter/src/components/tiny-robot-chat.vue
@@ -119,7 +119,7 @@ import { PromptProps } from '@opentiny/tiny-robot'
 import { GeneratingStatus, STATUS } from '@opentiny/tiny-robot-kit'
 import { IconNewSession, IconPlugin, IconHistory } from '@opentiny/tiny-robot-svgs'
 import { useTinyRobotChat } from '../composable/useTinyRobotChat'
-import { nextTick, watch, h, CSSProperties, toRef, computed, ref, onMounted } from 'vue'
+import { h, CSSProperties, toRef, computed, ref, onMounted } from 'vue'
 import { createRemoter, McpServerConfig } from '@opentiny/next-sdk'
 import QrCodeScan from './qr-code-scan.vue'
 import { DEFAULT_SERVERS } from './default-mcps'
@@ -379,20 +379,6 @@ if (props.mode === 'remoter') {
     }
   })
 }
-
-// 最新消息滚动到底部
-const scrollToBottom = () => {
-  const containerBody = document.querySelector('div.tr-bubble-list')
-  if (containerBody) {
-    nextTick(() => {
-      containerBody.scrollTo({
-        top: containerBody.scrollHeight,
-        behavior: 'smooth'
-      })
-    })
-  }
-}
-watch(() => messages.value[messages.value.length - 1]?.content, scrollToBottom)
 
 // 对接 mcp server picker 组件
 const pluginVisible = ref(false)

--- a/packages/next-remoter/src/components/tiny-robot-chat.vue
+++ b/packages/next-remoter/src/components/tiny-robot-chat.vue
@@ -4,8 +4,19 @@
       <h3 class="tr-container__title">{{ title }}</h3>
     </template>
     <template #operations>
-      <tr-icon-button :icon="IconNewSession" size="28" svgSize="20" @click="createConversation()" />
+      <tr-icon-button :icon="IconNewSession" size="28" svgSize="20" @click="handleCreateConversation()" />
+      <tr-icon-button :icon="IconHistory" size="28" svgSize="20" @click="showHistory = !showHistory" />
       <QrCodeScan @scanSuccess="handleScanSuccess" />
+
+      <TrHistory
+        v-show="showHistory"
+        class="tr-history-demo"
+        tab-title="历史会话"
+        :selected="conversationState.currentId"
+        :data="conversationState.conversations"
+        @close="showHistory = false"
+        @item-click="handleHistorySelect"
+      ></TrHistory>
     </template>
     <tr-bubble-provider :content-renderers="contentRenderer">
       <slot name="welcome" v-if="messages.length === 0">
@@ -99,13 +110,14 @@ import {
   TrIconButton,
   BubbleMarkdownContentRenderer,
   TrMcpServerPicker,
+  TrHistory,
   type PluginInfo,
   type MarketCategoryOption,
   type PluginTool
 } from '@opentiny/tiny-robot'
 import { PromptProps } from '@opentiny/tiny-robot'
 import { GeneratingStatus, STATUS } from '@opentiny/tiny-robot-kit'
-import { IconNewSession, IconPlugin } from '@opentiny/tiny-robot-svgs'
+import { IconNewSession, IconPlugin, IconHistory } from '@opentiny/tiny-robot-svgs'
 import { useTinyRobotChat } from '../composable/useTinyRobotChat'
 import { nextTick, watch, h, CSSProperties, toRef, computed, ref, onMounted } from 'vue'
 import { createRemoter, McpServerConfig } from '@opentiny/next-sdk'
@@ -158,8 +170,10 @@ const fullscreen = defineModel('fullscreen', { type: Boolean, default: false })
 const show = defineModel('show', { type: Boolean, default: false })
 
 const {
+  showHistory,
   agent, // ai-sdk的自定义代理，client通过它和llm 对话。 agent.ignoreToolnames=[] 是记录需要过滤掉的tools
   welcomeIcon,
+  conversationState,
   messages,
   messageState,
   inputMessage,
@@ -168,11 +182,13 @@ const {
   senderRef,
   sendMessage,
   handleSendMessage,
-  createConversation
+  createConversation,
+  handleHistorySelect,
+  handleCreateConversation
 } = useTinyRobotChat({
   sessionId: toRef(props, 'sessionId'),
   agentRoot: toRef(props, 'agentRoot'),
-  systemPrompt: props.systemPrompt
+  systemPrompt: props.systemPrompt || ''
 })
 
 const lang: Record<string, { title: string; description: string; placeholder: string; thinking: string }> = {
@@ -189,11 +205,6 @@ const lang: Record<string, { title: string; description: string; placeholder: st
     thinking: 'Thinking...'
   }
 }
-
-// 页面加载时，创建会话
-onMounted(() => {
-  createConversation()
-})
 
 // 自动计算的变量
 const senderPlaceholder = computed(() =>
@@ -589,5 +600,16 @@ defineExpose({
   :deep(.mcp-server-picker.popup-type-drawer) {
     width: 100% !important;
   }
+}
+
+.tr-history-demo {
+  position: absolute !important;
+  right: 134px;
+  top: 85px;
+
+  z-index: var(--tr-z-index-popover);
+  width: 300px;
+  height: 600px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.04);
 }
 </style>

--- a/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
+++ b/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
@@ -5,9 +5,7 @@ import { BaseModelProvider } from '@opentiny/tiny-robot-kit'
 import type { AIModelConfig } from '@opentiny/tiny-robot-kit'
 import { type Ref } from 'vue'
 import { AgentModelProvider, McpServerConfig, IAgentModelProviderOption } from '@opentiny/next-sdk'
-import { tool } from 'ai'
-import dayjs from 'dayjs'
-import { z } from 'zod'
+import { getToday } from './tools'
 
 /** Tiny-robot 所需要的自定义大语言的Provider */
 export class CustomAgentModelProvider extends BaseModelProvider {
@@ -44,29 +42,17 @@ export class CustomAgentModelProvider extends BaseModelProvider {
     this.systemPrompt = systemPrompt
   }
 
-  /** 同步请求不需要实现 */
-  chat(request: ChatCompletionRequest): Promise<ChatCompletionResponse> {
-    throw new Error('Method not implemented.')
-  }
-
   async chatStream(request: ChatCompletionRequest, handler: StreamHandler): Promise<void> {
     // 读取用户最新的请求
     const lastUserMsg = request.messages[request.messages.length - 1]
     if (!lastUserMsg) return
+
     const result = await this.agent.chatStream({
-      message: lastUserMsg.content as string,
+      message: lastUserMsg.content as string, // 只推入一条消息
       model: 'deepseek-ai/DeepSeek-V3',
       system: this.systemPrompt,
       abortSignal: request.options?.signal,
-      tools: {
-        'get-today': tool({
-          description: '获取今天的日期',
-          inputSchema: z.object({}),
-          execute: () => ({
-            date: `当前日期: ${dayjs().format('YYYY-M-D')}`
-          })
-        })
-      },
+      tools: { ['get-today']: getToday },
       maxSteps: 15
     })
 
@@ -131,5 +117,10 @@ export class CustomAgentModelProvider extends BaseModelProvider {
     }
 
     handler.onDone()
+  }
+
+  /** 同步请求不需要实现 */
+  chat(request: ChatCompletionRequest): Promise<ChatCompletionResponse> {
+    throw new Error('Method not implemented.')
   }
 }

--- a/packages/next-remoter/src/composable/tools.ts
+++ b/packages/next-remoter/src/composable/tools.ts
@@ -1,0 +1,11 @@
+import { z } from '@opentiny/next-sdk'
+import { tool } from 'ai'
+import dayjs from 'dayjs'
+
+export const getToday = tool({
+  description: '获取今天的日期',
+  inputSchema: z.object({}),
+  execute: () => ({
+    date: `当前日期: ${dayjs().format('YYYY-M-D')}`
+  })
+})

--- a/packages/next-remoter/src/composable/useTinyRobotChat.ts
+++ b/packages/next-remoter/src/composable/useTinyRobotChat.ts
@@ -113,6 +113,7 @@ export const useTinyRobotChat = ({ sessionId, agentRoot, systemPrompt }: useTiny
     switchConversation(item.id)
     const conv = getCurrentConversation()!
     customAgentProvider.agent.messages = conv.aiSdkMessages // 切换历史对话到当前代理上
+    showHistory.value = false
   }
   // 页面加载完成后自动聚焦输入框
   onMounted(() => {

--- a/packages/next-remoter/src/composable/useTinyRobotChat.ts
+++ b/packages/next-remoter/src/composable/useTinyRobotChat.ts
@@ -18,14 +18,19 @@ export const useTinyRobotChat = ({ sessionId, agentRoot, systemPrompt }: useTiny
     provider: 'custom'
   })
 
-  const fullscreen = ref(false)
-  const show = ref(true)
+  const showHistory = ref(false)
 
   const aiAvatar = h(logo, { style: { fontSize: '32px' } })
   const userAvatar = h(IconUser, { style: { fontSize: '32px' } })
   const welcomeIcon = h(logo, { style: { width: '48px', height: '48px' } })
 
-  const { messageManager, createConversation } = useConversation({
+  const {
+    messageManager,
+    createConversation,
+    getCurrentConversation,
+    switchConversation,
+    state: conversationState // 记录着所有的会话和 currentId
+  } = useConversation({
     client,
     events: {
       onReceiveData(data, messages, preventDefault) {
@@ -85,15 +90,35 @@ export const useTinyRobotChat = ({ sessionId, agentRoot, systemPrompt }: useTiny
   }
   const senderRef = ref<InstanceType<typeof TrSender>>()
 
-  // 发送消息
+  // 发送消息。 第一次发送，修改会话title
   const handleSendMessage = () => {
+    const conv = getCurrentConversation()
+    if (conv && conv.title === '新会话') {
+      conv.title = inputMessage.value.slice(0, 15)
+    }
     sendMessage(inputMessage.value)
   }
 
+  const handleCreateConversation = () => {
+    abortRequest()
+    const aiSdkMessages: any[] = []
+    customAgentProvider.agent.messages = aiSdkMessages
+    conversationState.currentId = createConversation()
+    const conv = getCurrentConversation()!
+    conv.aiSdkMessages = aiSdkMessages // 保存同一个引用到会话中
+  }
+
+  const handleHistorySelect = (item: { id: string }) => {
+    abortRequest()
+    switchConversation(item.id)
+    const conv = getCurrentConversation()!
+    customAgentProvider.agent.messages = conv.aiSdkMessages // 切换历史对话到当前代理上
+  }
   // 页面加载完成后自动聚焦输入框
   onMounted(() => {
     setTimeout(() => {
       senderRef.value?.focus()
+      handleCreateConversation() // 每次刷新，都是新会话
     }, 500)
   })
 
@@ -105,13 +130,13 @@ export const useTinyRobotChat = ({ sessionId, agentRoot, systemPrompt }: useTiny
     /**  一个 ai-sdk agent 封装,详见： next-sdk/AgentModelProvider 类 */
     agent: customAgentProvider.agent,
     client,
-    fullscreen,
-    show,
+    showHistory,
     aiAvatar,
     userAvatar,
     welcomeIcon,
 
     messageManager,
+    conversationState,
     messages,
     messageState,
     inputMessage,
@@ -120,10 +145,8 @@ export const useTinyRobotChat = ({ sessionId, agentRoot, systemPrompt }: useTiny
     roles,
     senderRef,
     handleSendMessage,
-    createConversation: () => {
-      customAgentProvider.agent.messages = []
-      abortRequest()
-      createConversation()
-    }
+    createConversation,
+    handleHistorySelect,
+    handleCreateConversation
   }
 }

--- a/packages/next-remoter/src/composable/useTinyRobotChat.ts
+++ b/packages/next-remoter/src/composable/useTinyRobotChat.ts
@@ -1,6 +1,6 @@
 import { AIClient, useConversation } from '@opentiny/tiny-robot-kit'
 import { IconUser } from '@opentiny/tiny-robot-svgs'
-import { h, onMounted, onUnmounted, Ref, ref } from 'vue'
+import { h, nextTick, onMounted, onUnmounted, Ref, ref, watch } from 'vue'
 import { CustomAgentModelProvider } from './CustomAgentModelProvider'
 import { TrSender } from '@opentiny/tiny-robot'
 import logo from '../../public/svgs/logo-next-no-bg-right.svg'
@@ -111,10 +111,28 @@ export const useTinyRobotChat = ({ sessionId, agentRoot, systemPrompt }: useTiny
   const handleHistorySelect = (item: { id: string }) => {
     abortRequest()
     switchConversation(item.id)
+
     const conv = getCurrentConversation()!
     customAgentProvider.agent.messages = conv.aiSdkMessages // 切换历史对话到当前代理上
     showHistory.value = false
+
+    scrollToBottom()
   }
+
+  // 最新消息滚动到底部
+  const scrollToBottom = () => {
+    nextTick(() => {
+      const containerBody = document.querySelector('div.tr-bubble-list')
+      if (containerBody) {
+        containerBody.scrollTo({
+          top: containerBody.scrollHeight,
+          behavior: 'smooth'
+        })
+      }
+    })
+  }
+  watch(() => messages.value[messages.value.length - 1]?.content, scrollToBottom)
+
   // 页面加载完成后自动聚焦输入框
   onMounted(() => {
     setTimeout(() => {

--- a/packages/next-sdk/agent/AgentModelProvider.ts
+++ b/packages/next-sdk/agent/AgentModelProvider.ts
@@ -39,6 +39,7 @@ export class AgentModelProvider {
   /** 内部报错时，抛出错误事件 */
   onError: ((msg: string, err?: any) => void) | undefined
 
+  /** 缓存 ai-sdk response 中的 多轮会话 */
   messages: any[] = []
 
   constructor({ llmConfig, mcpServers, llm }: IAgentModelProviderOption) {
@@ -176,7 +177,7 @@ export class AgentModelProvider {
   }
 
   /** 创建临时允许调用的tools集合 */
-  tempMergeTools(extraTool = {}) {
+  private _tempMergeTools(extraTool = {}) {
     const toolsResult = this.mcpTools.reduce((acc, curr) => ({ ...acc, ...curr }), {})
     Object.assign(toolsResult, extraTool)
 
@@ -186,7 +187,7 @@ export class AgentModelProvider {
     return toolsResult
   }
 
-  async _chat(
+  private async _chat(
     chatMethod: ChatMethodFn,
     { model, maxSteps = 5, ...options }: Parameters<typeof generateText>[0] & { maxSteps?: number; message?: string }
   ): Promise<any> {
@@ -204,7 +205,7 @@ export class AgentModelProvider {
       model: this.llm(model),
       stopWhen: stepCountIs(maxSteps),
       ...options,
-      tools: this.tempMergeTools(options.tools) as ToolSet
+      tools: this._tempMergeTools(options.tools) as ToolSet
     }
 
     if (options.message && !options.messages) {
@@ -214,6 +215,7 @@ export class AgentModelProvider {
 
     const result = chatMethod(chatOptions)
 
+    // 缓存 ai-sdk的多轮对话的消息
     ;(result as StreamTextResult<ToolSet, unknown>)?.response?.then((res: any) => {
       this.messages.push(...res.messages)
     })


### PR DESCRIPTION
[fix(remoter): 增加会话历史和切换会话](https://github.com/opentiny/next-sdk/commit/ec054d6599130c730b384bf9c23aa14c84e49ae5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Conversation history panel with a toggle button to view and select past sessions.
  - Create new sessions from the chat; new conversations auto-title from the first message.
  - Per-conversation messages preserved when switching.
  - New "today" tool to return the current date on request.

- **Improvements**
  - Autofocus input and automatic scroll to latest messages.
  - More consistent multi-turn context and cached agent responses.

- **Refactor**
  - Simplified internal tool integration and message caching for more stable session handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->