### PR TITLE
feat: Add command code function to quickly access mcp tool

### DIFF
--- a/packages/next-remoter/auto-imports.d.ts
+++ b/packages/next-remoter/auto-imports.d.ts
@@ -6,5 +6,7 @@
 // biome-ignore lint: disable
 export {}
 declare global {
+  const closeToast: typeof import('vant/es')['closeToast']
+  const showLoadingToast: typeof import('vant/es')['showLoadingToast']
   const showToast: typeof import('vant/es')['showToast']
 }

--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-remoter",
-  "version": "0.0.1-alpha.20",
+  "version": "0.0.1-alpha.22",
   "type": "module",
   "files": [
     "dist"

--- a/packages/next-remoter/src/components/qr-code-scan.vue
+++ b/packages/next-remoter/src/components/qr-code-scan.vue
@@ -58,8 +58,14 @@ const start = () => {
         useBarCodeDetectorIfSupported: true // 使用更快的条码检测器
       },
       (decodedText) => {
-        emit('scanSuccess', decodedText)
-        showToast('添加工具完成')
+        const url = new URL(decodedText)
+        const sessionId = url.searchParams.get('sessionId')
+        if (sessionId) {
+          emit('scanSuccess', sessionId)
+        } else {
+          showToast('无效的二维码')
+        }
+
         stop()
       }
     )

--- a/packages/next-remoter/src/components/qr-code-scan.vue
+++ b/packages/next-remoter/src/components/qr-code-scan.vue
@@ -58,14 +58,17 @@ const start = () => {
         useBarCodeDetectorIfSupported: true // 使用更快的条码检测器
       },
       (decodedText) => {
-        const url = new URL(decodedText)
-        const sessionId = url.searchParams.get('sessionId')
-        if (sessionId) {
-          emit('scanSuccess', sessionId)
-        } else {
+        try {
+          const url = new URL(decodedText)
+          const sessionId = url.searchParams.get('sessionId')
+          if (sessionId) {
+            emit('scanSuccess', sessionId)
+          } else {
+            showToast('无效的二维码')
+          }
+        } catch (error) {
           showToast('无效的二维码')
         }
-
         stop()
       }
     )

--- a/packages/next-remoter/src/components/tiny-robot-chat.vue
+++ b/packages/next-remoter/src/components/tiny-robot-chat.vue
@@ -193,14 +193,19 @@ const {
 
 const handleSendMessageCustom = async () => {
   const input = inputMessage.value
-  if (/\/[A-Za-z0-9]{6}/.test(input)) {
+  if (/^\/[A-Za-z0-9-]{6,}$/.test(input)) {
     showLoadingToast('添加工具中...')
     const res = await fetch(`${props.agentRoot}client?sessionId=${input.slice(1)}`).then((res) => res.json())
-    const sessionId = res.data.sessionId
-    await handleScanSuccess(sessionId)
-    showToast('添加工具完成')
+    const sessionId = res?.data?.sessionId
+
+    if (sessionId) {
+      await handleScanSuccess(sessionId)
+      showToast('添加工具完成')
+    } else {
+      showToast('添加工具失败,请检查 code 码是否正确')
+    }
+
     inputMessage.value = ''
-    closeToast()
   } else {
     handleSendMessage()
   }

--- a/packages/next-remoter/src/components/tiny-robot-chat.vue
+++ b/packages/next-remoter/src/components/tiny-robot-chat.vue
@@ -53,7 +53,7 @@
           :loading="senderLoading"
           :showWordLimit="true"
           :maxLength="1000"
-          @submit="handleSendMessage"
+          @submit="handleSendMessageCustom"
           @cancel="abortRequest"
         >
           <template #footer-left>
@@ -175,6 +175,21 @@ const {
   systemPrompt: props.systemPrompt
 })
 
+const handleSendMessageCustom = async () => {
+  const input = inputMessage.value
+  if (/\/[A-Za-z0-9]{6}/.test(input)) {
+    showLoadingToast('添加工具中...')
+    const res = await fetch(`${props.agentRoot}client?sessionId=${input.slice(1)}`).then((res) => res.json())
+    const sessionId = res.data.sessionId
+    await handleScanSuccess(sessionId)
+    showToast('添加工具完成')
+    inputMessage.value = ''
+    closeToast()
+  } else {
+    handleSendMessage()
+  }
+}
+
 const lang: Record<string, { title: string; description: string; placeholder: string; thinking: string }> = {
   'zh-CN': {
     title: 'OpenTiny NEXT',
@@ -271,10 +286,7 @@ const handlePillItemClick = (item: ReturnType<typeof mapMake>) => {
 }
 
 // 处理扫码结果。 把结果添加到 agent.mcpServers， 以及 插入McpServerPicker的一个Plugin
-const handleScanSuccess = async (decodedText: string) => {
-  const url = new URL(decodedText)
-  const sessionId = url.searchParams.get('sessionId')
-
+const handleScanSuccess = async (sessionId: string) => {
   if (sessionId) {
     const mcpServer = {
       type: 'streamableHttp',
@@ -285,7 +297,10 @@ const handleScanSuccess = async (decodedText: string) => {
 
     if (inserted) {
       loadMcpServerToPlugin(mcpServer)
+      showToast('添加工具完成')
     }
+  } else {
+    showToast('添加工具失败')
   }
 }
 

--- a/packages/next-remoter/src/composable/useTinyRobotChat.ts
+++ b/packages/next-remoter/src/composable/useTinyRobotChat.ts
@@ -87,7 +87,8 @@ export const useTinyRobotChat = ({ sessionId, agentRoot, systemPrompt }: useTiny
 
   // 发送消息
   const handleSendMessage = () => {
-    sendMessage(inputMessage.value)
+    const input = inputMessage.value
+    sendMessage(input)
   }
 
   // 页面加载完成后自动聚焦输入框

--- a/packages/next-remoter/src/main.ts
+++ b/packages/next-remoter/src/main.ts
@@ -4,6 +4,6 @@ import App from './App.vue'
 import '@opentiny/tiny-robot/dist/style.css'
 import { setToastDefaultOptions } from 'vant'
 
-setToastDefaultOptions({ duration: 2000 })
+setToastDefaultOptions({ duration: 1000 })
 const app = createApp(App)
 app.mount('#app')

--- a/packages/next-sdk/package.json
+++ b/packages/next-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-sdk",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "license": "MIT",
   "author": "Chunhui Mo",


### PR DESCRIPTION
feat: 添加指令code码功能，快捷接入mcp工具

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat input supports a slash command (e.g., /ABC123) to link a session and auto-connect a tool with loading and completion toasts.

* **Bug Fixes**
  * QR code scanning now validates URLs, extracts sessionId, and only reports success when valid; shows an error toast for invalid codes.

* **Improvements**
  * Toasts now display for a shorter duration (faster feedback).

* **Chores**
  * Bumped versions: next-remoter → 0.0.1-alpha.22; next-sdk → 0.1.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->