### PR TITLE
fix(remoter):  添加编辑和删除历史会话的功能

### DIFF
--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -25,6 +25,7 @@
     "@opentiny/tiny-robot-svgs": "0.3.0-rc.3",
     "@modelcontextprotocol/sdk": "^1.16.0",
     "@opentiny/vue": "^3.25.0",
+    "@opentiny/vue-directive": "^3.25.0",
     "@opentiny/vue-icon": "^3.25.0",
     "html5-qrcode": "^2.3.8",
     "vant": "^4.9.21",

--- a/packages/next-remoter/src/components/tiny-robot-chat.vue
+++ b/packages/next-remoter/src/components/tiny-robot-chat.vue
@@ -4,9 +4,21 @@
       <h3 class="tr-container__title">{{ title }}</h3>
     </template>
     <template #operations>
-      <tr-icon-button :icon="IconNewSession" size="28" svgSize="20" @click="handleCreateConversation()" />
-      <tr-icon-button :icon="IconHistory" size="28" svgSize="20" @click="showHistory = !showHistory" />
-      <QrCodeScan @scanSuccess="handleScanSuccess" />
+      <tr-icon-button
+        :icon="IconNewSession"
+        v-auto-tip="{ always: true, content: '新建会话', effect: 'dark' }"
+        size="28"
+        svgSize="20"
+        @click="handleCreateConversation()"
+      />
+      <tr-icon-button
+        :icon="IconHistory"
+        v-auto-tip="{ always: true, content: '历史会话', effect: 'dark' }"
+        size="28"
+        svgSize="20"
+        @click="showHistory = !showHistory"
+      />
+      <QrCodeScan @scanSuccess="handleScanSuccess" v-auto-tip="{ always: true, content: '应用扫码', effect: 'dark' }" />
 
       <!-- 历史会话抽屉 -->
       <Transition name="drawer-slide" appear>
@@ -19,6 +31,8 @@
               :data="conversationState.conversations"
               @close="showHistory = false"
               @item-click="handleHistorySelect"
+              @item-title-change="handleHistoryUpdateTitle"
+              @item-delete="handleHistoryDelete"
             ></TrHistory>
           </div>
         </div>
@@ -131,6 +145,9 @@ import QrCodeScan from './qr-code-scan.vue'
 import { DEFAULT_SERVERS } from './default-mcps'
 import { defaultPluginSrc } from './default-plugin-svg'
 import { SYSTEM_PROMPT } from '../const'
+import { AutoTip } from '@opentiny/vue-directive'
+
+const VAutoTip = AutoTip
 
 defineOptions({
   name: 'TinyRemoter'
@@ -188,7 +205,9 @@ const {
   senderRef,
   sendMessage,
   handleSendMessage,
-  createConversation,
+
+  handleHistoryUpdateTitle,
+  handleHistoryDelete,
   handleHistorySelect,
   handleCreateConversation
 } = useTinyRobotChat({

--- a/packages/next-remoter/src/composable/useTinyRobotChat.ts
+++ b/packages/next-remoter/src/composable/useTinyRobotChat.ts
@@ -29,6 +29,7 @@ export const useTinyRobotChat = ({ sessionId, agentRoot, systemPrompt }: useTiny
     createConversation,
     getCurrentConversation,
     switchConversation,
+    deleteConversation,
     state: conversationState // 记录着所有的会话和 currentId
   } = useConversation({
     client,
@@ -119,6 +120,15 @@ export const useTinyRobotChat = ({ sessionId, agentRoot, systemPrompt }: useTiny
     scrollToBottom()
   }
 
+  const handleHistoryUpdateTitle = (title: string) => {
+    const conv = getCurrentConversation()
+    conv.title = title
+  }
+
+  const handleHistoryDelete = (item: { id: string }) => {
+    deleteConversation(item.id)
+  }
+
   // 最新消息滚动到底部
   const scrollToBottom = () => {
     nextTick(() => {
@@ -166,6 +176,8 @@ export const useTinyRobotChat = ({ sessionId, agentRoot, systemPrompt }: useTiny
     handleSendMessage,
     createConversation,
     handleHistorySelect,
-    handleCreateConversation
+    handleCreateConversation,
+    handleHistoryUpdateTitle,
+    handleHistoryDelete
   }
 }


### PR DESCRIPTION
fix(remoter):  添加编辑和删除历史会话的功能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Chat history now supports renaming conversation titles and deleting conversations directly from the History panel.
* Style
  * Added persistent dark tooltips to top-operation icons (New Session, History, App Scan), including the QR code scan button, for clearer guidance.
* Chores
  * Added a new UI directive dependency to support enhanced tooltip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->