### PR TITLE
feat: Add remoteUrl configuration, change the default address to robot product state

### DIFF
--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-remoter",
-  "version": "0.0.1-alpha.22",
+  "version": "0.0.1-alpha.24",
   "type": "module",
   "files": [
     "dist"

--- a/packages/next-remoter/src/components/tiny-robot-chat.vue
+++ b/packages/next-remoter/src/components/tiny-robot-chat.vue
@@ -179,6 +179,12 @@ const props = defineProps({
     type: String,
     default: 'zh-CN'
   },
+  remoteUrl: {
+    type: String
+  },
+  qrCodeUrl: {
+    type: String
+  },
   /** 展示模式： 'remoter' | 'chat-dialog'
    * 遥控器模式： 自动在右下角显示一个AI图标，点击展开多个菜单项。
    * 对话框模式： 直接显示一个对话框界面
@@ -384,6 +390,8 @@ const contentRenderer = { markdown: new BubbleMarkdownContentRenderer({ mdConfig
 if (props.mode === 'remoter') {
   createRemoter({
     sessionId: props.sessionId,
+    qrCodeUrl: props.qrCodeUrl,
+    remoteUrl: props.remoteUrl,
     onShowAIChat: () => {
       show.value = true
     }

--- a/packages/next-sdk/package.json
+++ b/packages/next-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-sdk",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "license": "MIT",
   "author": "Chunhui Mo",

--- a/packages/next-sdk/remoter/createRemoter.ts
+++ b/packages/next-sdk/remoter/createRemoter.ts
@@ -1,5 +1,8 @@
 import { QrCode } from './QrCode'
 
+const DEFAULT_REMOTE_URL = 'https://agent.opentiny.design/tiny-robot'
+const DEFAULT_QR_CODE_URL = 'https://ai.opentiny.design/next-remoter'
+
 /** 菜单项配置接口 */
 interface MenuItemConfig {
   /** 菜单项标识 */
@@ -27,6 +30,8 @@ interface FloatingBlockOptions {
   sessionId: string
   /** 菜单项配置 */
   menuItems?: MenuItemConfig[]
+  /** 遥控端页面地址，默认为： https://agent.opentiny.design/tiny-robot */
+  remoteUrl?: string
 }
 
 // 动作类型
@@ -80,8 +85,8 @@ const getDefaultMenuItems = (options: FloatingBlockOptions): MenuItemConfig[] =>
     {
       action: 'remote-url',
       show: true,
-      text: `${options.qrCodeUrl}`,
-      tip: options.qrCodeUrl,
+      text: `${options.remoteUrl}`,
+      tip: options.remoteUrl,
       showCopyIcon: true,
       icon: `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
@@ -109,8 +114,9 @@ class FloatingBlock {
     }
 
     this.options = {
-      qrCodeUrl: options.qrCodeUrl || 'https://ai.opentiny.design/next-remoter',
-      ...options
+      ...options,
+      qrCodeUrl: options.qrCodeUrl || DEFAULT_QR_CODE_URL,
+      remoteUrl: options.remoteUrl || DEFAULT_REMOTE_URL
     }
 
     // 合并默认菜单项配置和用户配置
@@ -156,7 +162,7 @@ class FloatingBlock {
     this.floatingBlock.className = 'tiny-remoter-floating-block'
     this.floatingBlock.innerHTML = `
       <div class="tiny-remoter-floating-block__icon">
-        <img style="display: block; width: 56px;" src="https://ai.opentiny.design/next-remoter/svgs/logo-next-no-bg-left.svg" alt="icon" />
+        <img style="display: block; width: 56px;" src="${DEFAULT_QR_CODE_URL}/svgs/logo-next-no-bg-left.svg" alt="icon" />
       </div>
     `
 
@@ -287,7 +293,7 @@ class FloatingBlock {
   }
 
   private copyRemoteURL(): void {
-    this.copyToClipboard((this.options.qrCodeUrl || '') + this.sessionPrefix + this.options.sessionId)
+    this.copyToClipboard(this.options.remoteUrl + this.sessionPrefix + this.options.sessionId)
   }
 
   // 实现复制到剪贴板功能


### PR DESCRIPTION
feat: 增加remoterUrl配置，将默认地址只想robot产品态

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configurable remoteUrl and qrCodeUrl to the TinyRemoter component and SDK options, with sensible defaults.
  - Clipboard now copies the full remote URL, and menu text/tooltips display the remote URL for clarity.
  - Updated floating icon to use the new default asset path.

- Chores
  - Bumped package versions for next-remoter (0.0.1-alpha.24) and next-sdk (0.1.8).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->