### PR TITLE
chore: Update @opentiny/next-remoter version to 0.0.2, and optimize the title and error handling logic of tiny-robot-chat component

### DIFF
--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-remoter",
-  "version": "0.0.1-alpha.25",
+  "version": "0.0.2",
   "type": "module",
   "files": [
     "dist"

--- a/packages/next-remoter/src/components/error-handle.ts
+++ b/packages/next-remoter/src/components/error-handle.ts
@@ -1,0 +1,12 @@
+const errorMap = {
+  'No client found for session ID': '受控端页面已关闭请重新打开或者刷新页面',
+  'Failed to create MCP client': '创建MCP客户端失败'
+}
+
+export const handleError = (message: string) => {
+  console.log('message', message)
+  const keys = Object.keys(errorMap)
+  const index = keys.findIndex((key) => message.includes(key))
+  const errorMessage = index !== -1 ? errorMap[keys[index] as keyof typeof errorMap] : message
+  return errorMessage || message
+}

--- a/packages/next-remoter/src/components/tiny-robot-chat.vue
+++ b/packages/next-remoter/src/components/tiny-robot-chat.vue
@@ -88,7 +88,9 @@
           v-model:visible="pluginVisible"
           :popup-config="{ type: 'drawer' }"
           :show-custom-add-button="false"
-          marketTabTitle="MCP 市场"
+          marketTabTitle="MCP市场"
+          installedTabTitle="已添加MCP服务"
+          title="扩展"
           :installedPlugins="installedPlugins"
           :marketPlugins="marketPlugins"
           :market-category-options="marketCategoryOptions"
@@ -133,6 +135,7 @@ import QrCodeScan from './qr-code-scan.vue'
 import { DEFAULT_SERVERS } from './default-mcps'
 import { defaultPluginSrc } from './default-plugin-svg'
 import { getLang, mapMake } from './lang'
+import { handleError } from './error-handle'
 
 defineOptions({
   name: 'TinyRemoter'
@@ -357,7 +360,7 @@ watch(
 onMounted(async () => {
   // 统一报错
   agent.onError = (msg) => {
-    msg && showToast(msg)
+    msg && showToast(handleError(msg))
   }
 
   // 每次chat的过程中，更新 tools 后，已安装的插件需要同步一次

--- a/packages/next-remoter/src/composable/useTinyRobotChat.ts
+++ b/packages/next-remoter/src/composable/useTinyRobotChat.ts
@@ -145,10 +145,8 @@ export const useTinyRobotChat = ({ sessionId, agentRoot, systemPrompt }: useTiny
 
   // 页面加载完成后自动聚焦输入框
   onMounted(() => {
-    setTimeout(() => {
-      senderRef.value?.focus()
-      handleCreateConversation() // 每次刷新，都是新会话
-    }, 500)
+    senderRef.value?.focus()
+    handleCreateConversation() // 每次刷新，都是新会话
   })
 
   onUnmounted(() => {


### PR DESCRIPTION
chore: 更新 @opentiny/next-remoter 版本至 0.0.2，并优化 tiny-robot-chat 组件的标题和错误处理逻辑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clearer, localized error messages in chat toasts for common connection issues, reducing confusion.
  * Chat opens ready-to-type: input focuses immediately and a new conversation starts right away for a faster start.
  * MCP picker labels updated for clarity: titles and tabs now read “扩展”, “已添加MCP服务”, and “MCP市场”.

* **Chores**
  * Bumped package version to 0.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->