### PR TITLE
feat: Update the MCP server configuration structure to support object-based input and optimize related documentation

### DIFF
--- a/docs/guide/api-agentModelProvider.mdx
+++ b/docs/guide/api-agentModelProvider.mdx
@@ -34,8 +34,8 @@ export interface IAgentModelProviderOption {
   llm?: ProviderV2
   /** 代理模型提供器的大语言配置对象, 不能与 llm 同时传入 */
   llmConfig?: IAgentModelProviderLlmConfig
-  /** Mcp Server的配置对象的集合 */
-  mcpServers?: McpServerConfig[]
+  /** Mcp Server的配置对象的集合，键为服务器名称，值为配置对象 */
+  mcpServers?: Record<string, McpServerConfig>
 }
 ```
 
@@ -94,13 +94,15 @@ const webAgent = new AgentModelProvider({
     baseURL: 'https://xxxxx',
     providerType: createAnthropic
   },
-  mcpServers: [{ type: 'streamableHttp', url: 'https://xxxx' }]
+  mcpServers: {
+    'my-mcp-server': { type: 'streamableHttp', url: 'https://xxxx' }
+  }
 })
 ```
 
 如上配置后，在每次对话时，都会通过上述的`Transport` 向 `McpServer` 询问所有的工具列表，并在对话时自动带上这些工具。
 
-如果指定了多个 `McpServerConfig` 对象，会给每一个 `McpServer`都建立连接，并查询工具后进行合并后，再进入对话。
+如果指定了多个 `McpServerConfig` 对象，会给每一个 `McpServer`都建立连接，并查询工具后进行合并后，再进入对话。每个服务器都需要有唯一的名称作为键。
 
 如果需要自定义 MCP 连接，请参考 [ai-sdk的初始化MCP Client](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling#initializing-an-mcp-client)
 
@@ -115,7 +117,9 @@ const webAgent = new AgentModelProvider({
     baseURL: 'https://xxxxx',
     providerType: 'deepseek'
   },
-  mcpServers: [{ type: 'streamableHttp', url: 'https://xxxx' }]
+  mcpServers: {
+    'my-mcp-server': { type: 'streamableHttp', url: 'https://xxxx' }
+  }
 })
 
 const generateTextResult = webAgent.chat({
@@ -159,13 +163,13 @@ const result = await webAgent.chat({
 
 ## `AgentModelProvider` 的实例方法
 
-| 方法名                | 类型                                                     | 参数                            | 返回值             | 描述                                                     |
-| --------------------- | -------------------------------------------------------- | ------------------------------- | ------------------ | -------------------------------------------------------- |
-| `closeAll`            | `async () => Promise<void>`                              | 无                              | `Promise<void>`    | 关闭所有 MCP 客户端连接                                  |
-| `updateMcpServers`    | `async (mcpServers: McpServerConfig[]) => Promise<void>` | `mcpServers: McpServerConfig[]` | `Promise<void>`    | 更新 MCP 服务器配置，会先关闭现有连接再重新初始化        |
-| `insertMcpServer`     | `async (mcpServer: McpServerConfig) => Promise<boolean>` | `mcpServer: McpServerConfig`    | `Promise<boolean>` | 插入新的 MCP 服务器配置，如果已存在相同 URL 则返回 false |
-| `removeMcpServer`     | `(mcpServer: McpServerConfig) => void`                   | `mcpServer: McpServerConfig`    | `void`             | 删除指定的 MCP 服务器配置并关闭对应连接                  |
-| `initClientsAndTools` | `async () => Promise<void>`                              | 无                              | `Promise<void>`    | 初始化所有 MCP 客户端和工具                              |
+| 方法名                | 类型                                                                         | 参数                                             | 返回值             | 描述                                                    |
+| --------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------ | ------------------ | ------------------------------------------------------- |
+| `closeAll`            | `async () => Promise<void>`                                                  | 无                                               | `Promise<void>`    | 关闭所有 MCP 客户端连接                                 |
+| `updateMcpServers`    | `async (mcpServers: Record<string, McpServerConfig>) => Promise<void>`       | `mcpServers: Record<string, McpServerConfig>`    | `Promise<void>`    | 更新 MCP 服务器配置，会先关闭现有连接再重新初始化       |
+| `insertMcpServer`     | `async (serverName: string, mcpServer: McpServerConfig) => Promise<boolean>` | `serverName: string, mcpServer: McpServerConfig` | `Promise<boolean>` | 插入新的 MCP 服务器配置，如果已存在相同名称则返回 false |
+| `removeMcpServer`     | `(serverName: string) => void`                                               | `serverName: string`                             | `void`             | 删除指定名称的 MCP 服务器配置并关闭对应连接             |
+| `initClientsAndTools` | `async () => Promise<void>`                                                  | 无                                               | `Promise<void>`    | 初始化所有 MCP 客户端和工具                             |
 
 ## `AgentModelProvider` 的实例属性
 
@@ -181,13 +185,15 @@ const result = await webAgent.chat({
 await webAgent.closeAll()
 
 // 更新 MCP 服务器配置
-await webAgent.updateMcpServers([{ type: 'streamableHttp', url: 'https://xxxx' }])
+await webAgent.updateMcpServers({
+  'my-mcp-server': { type: 'streamableHttp', url: 'https://xxxx' }
+})
 
 // 插入新的 MCP 服务器
-const success = await webAgent.insertMcpServer({ type: 'streamableHttp', url: 'https://yyyy' })
+const success = await webAgent.insertMcpServer('new-server', { type: 'streamableHttp', url: 'https://yyyy' })
 
 // 删除 MCP 服务器
-webAgent.removeMcpServer({ type: 'streamableHttp', url: 'https://xxxx' })
+webAgent.removeMcpServer('my-mcp-server')
 
 // 设置工具更新回调
 webAgent.onUpdatedTools = () => {

--- a/packages/doc-ai/src/components/ant-design-x.vue
+++ b/packages/doc-ai/src/components/ant-design-x.vue
@@ -133,12 +133,12 @@ const webAgent = new AgentModelProvider({
     baseURL: 'https://agent.opentiny.design/api/v1/ai',
     providerType: 'deepseek'
   },
-  mcpServers: [
-    {
+  mcpServers: {
+    'mcp-server-main': {
       type: 'streamableHttp',
       url: `${AGENT_ROOT}mcp?sessionId=${SSEION_ID}`
     }
-  ]
+  }
 })
 
 // ==================== Runtime ====================

--- a/packages/next-remoter/src/components/tiny-robot-chat.vue
+++ b/packages/next-remoter/src/components/tiny-robot-chat.vue
@@ -241,11 +241,12 @@ const handleScanSuccess = async (sessionId: string) => {
       type: 'streamableHttp',
       url: `${props.agentRoot}mcp?sessionId=${sessionId}`
     } as const
+    const serverName = `mcp-server-${sessionId}`
     // 1、 插入McpServers, 此时内部会判断重复。  不重复则插入，并连接和查询tools到agent上。
-    const inserted = await agent.insertMcpServer(mcpServer)
+    const inserted = await agent.insertMcpServer(serverName, mcpServer)
 
     if (inserted) {
-      await loadMcpServerToPlugin(mcpServer)
+      await loadMcpServerToPlugin(serverName, mcpServer)
       await agent.closeAll()
       showToast('添加工具完成')
     } else {
@@ -285,9 +286,17 @@ const handlePillItemClick = (item: ReturnType<typeof mapMake>) => {
   inputMessage.value = item.inputMessage
 }
 
-const loadMcpServerToPlugin = async (mcpServer: McpServerConfig) => {
+const loadMcpServerToPlugin = async (serverName: string, mcpServer: McpServerConfig) => {
   // 先查找 index, 由它可以找到相应的 client, tool
-  const index = agent.mcpServers.findIndex((svc) => svc.url === mcpServer.url)
+  const serverNames = Object.keys(agent.mcpServers)
+  const index = serverNames.indexOf(serverName)
+
+  // 检查 mcpServer 是否有 url 属性
+  if (!('url' in mcpServer)) {
+    console.warn('MCP server config does not have url property')
+    return
+  }
+
   // 解析url, 获得sessionId
   const url = new URL(mcpServer.url)
   const sessionId = url.searchParams.get('sessionId') || ''
@@ -311,6 +320,7 @@ const loadMcpServerToPlugin = async (mcpServer: McpServerConfig) => {
     if (existingPlugin) {
       // 如果插件已存在，更新其工具列表和配置
       existingPlugin.tools = pluginTools
+      // @ts-ignore
       existingPlugin.originMcpConfig = markRaw(mcpServer) as McpServerConfig
       return
     }
@@ -340,8 +350,11 @@ onMounted(async () => {
   // 每次chat的过程中会自动更新 tools ，所以已安装的插件需要同步一次
   agent.onUpdatedTools = () => {
     installedPlugins.value.forEach((plugin) => {
-      const mcpServer = plugin.originMcpConfig as McpServerConfig
-      const index = agent.mcpServers.findIndex((server) => server === mcpServer)
+      // 通过插件ID找到对应的服务器名称
+      const serverName = `mcp-server-${plugin.id.replace('plugin-', '')}`
+      const serverNames = Object.keys(agent.mcpServers)
+      const index = serverNames.indexOf(serverName)
+
       // 先判断client 在不在， 不存在后，标记一个 (断)
       if (index !== -1) {
         const currClient = agent.mcpClients[index]
@@ -374,8 +387,8 @@ onMounted(async () => {
   await agent.initClientsAndTools()
   await agent.closeAll()
 
-  for (const mcpServer of agent.mcpServers) {
-    await loadMcpServerToPlugin(mcpServer)
+  for (const [serverName, mcpServer] of Object.entries(agent.mcpServers)) {
+    await loadMcpServerToPlugin(serverName, mcpServer)
   }
 })
 
@@ -392,12 +405,12 @@ if (props.mode === 'remoter') {
 }
 
 // 整个插件的打开或关闭
-const handlePluginToggle = (plugin: PluginInfo, enabled: boolean) => {
+const handlePluginToggle = () => {
   // Keep empty!
 }
 
 // 某个tool的打开或关闭。  全部tool状态一致时，会同时触发handlePluginToggle 一下。
-const handleToolToggle = (plugin: PluginInfo, toolId: string, enabled: boolean) => {
+const handleToolToggle = (_plugin: PluginInfo, toolId: string, enabled: boolean) => {
   if (enabled) {
     agent.ignoreToolnames = agent.ignoreToolnames.filter((name) => name !== toolId)
   } else {
@@ -416,11 +429,13 @@ const handlePluginDelete = async (plugin: PluginInfo) => {
     }
 
     // 移除mcpServers，mcpTools，mcpClients，ignoreToolnames
-    await agent.removeMcpServer(delPlugin.originMcpConfig as McpServerConfig)
+    // 通过插件ID找到对应的服务器名称
+    const serverName = `mcp-server-${plugin.id.replace('plugin-', '')}`
+    await agent.removeMcpServer(serverName)
   }
 }
-// 插件市场中，点击“添加”
-const handlePluginAdd = async (plugin: PluginInfo, isAdd: boolean) => {
+// 插件市场中，点击"添加"
+const handlePluginAdd = async (plugin: PluginInfo) => {
   plugin.addState = 'loading'
 
   const newPlugin = {
@@ -430,11 +445,13 @@ const handlePluginAdd = async (plugin: PluginInfo, isAdd: boolean) => {
   }
 
   // 立即注册服务，查询工具
-  const mcpServer = { type: plugin.type, url: plugin.url }
-  const inserted = await agent.insertMcpServer(mcpServer) // 插入时，会自动去重，且initClientAndTools
+  const mcpServer = { type: plugin.type, url: (plugin as any).url } as McpServerConfig
+  const serverName = `mcp-server-${plugin.id}`
+  const inserted = await agent.insertMcpServer(serverName, mcpServer) // 插入时，会自动去重，且initClientAndTools
   if (inserted) {
-    newPlugin.originMcpConfig = markRaw(mcpServer)
-    const index = agent.mcpServers.findIndex((svc) => svc.url === mcpServer.url)
+    // 通过服务器名称找到对应的索引
+    const serverNames = Object.keys(agent.mcpServers)
+    const index = serverNames.indexOf(serverName)
     // 查询 tools
     const currTool = agent.mcpTools[index]
     if (currTool) {
@@ -446,14 +463,14 @@ const handlePluginAdd = async (plugin: PluginInfo, isAdd: boolean) => {
           enabled: true
         }
       })
-      installedPlugins.value.push(newPlugin) // 只有client.tools() 成功了，才显示到“已安装列表”
+      installedPlugins.value.push(newPlugin) // 只有client.tools() 成功了，才显示到"已安装列表"
       plugin.addState = 'added'
       await agent.closeAll()
       return
     }
   }
   // 添加失败
-  await agent.removeMcpServer(mcpServer)
+  await agent.removeMcpServer(serverName)
   plugin.addState = 'idle'
 }
 

--- a/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
+++ b/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
@@ -53,17 +53,21 @@ export class CustomAgentModelProvider extends BaseModelProvider {
    * 创建MCP服务器配置
    * @param sessionId 会话ID，支持逗号分隔的多个ID
    * @param agentRoot 代理根路径
-   * @returns MCP服务器配置数组
+   * @returns MCP服务器配置对象，键为服务器名称，值为配置对象
    */
-  private createMcpServers(sessionId: string, agentRoot: string): McpServerConfig[] {
-    if (!sessionId) return []
+  private createMcpServers(sessionId: string, agentRoot: string): Record<string, McpServerConfig> {
+    if (!sessionId) return {}
 
     const sessionIds = sessionId.includes(',') ? sessionId.split(',').map((id) => id.trim()) : [sessionId]
 
-    return sessionIds.map((id) => ({
-      type: 'streamableHttp' as const,
-      url: `${agentRoot}mcp?sessionId=${id}`
-    }))
+    const servers: Record<string, McpServerConfig> = {}
+    sessionIds.forEach((id) => {
+      servers[`mcp-server-${id}`] = {
+        type: 'streamableHttp' as const,
+        url: `${agentRoot}mcp?sessionId=${id}`
+      }
+    })
+    return servers
   }
 
   /**

--- a/packages/next-sdk/agent/AgentModelProvider.ts
+++ b/packages/next-sdk/agent/AgentModelProvider.ts
@@ -21,9 +21,9 @@ type ChatMethodFn = typeof streamText | typeof generateText
  */
 export class AgentModelProvider {
   llm: ProviderV2 | OpenAIProvider
-  /**  当前mcpServers数组集合。 mcpServer 允许为配置为 McpServerConfig, 或者任意的 MCPTransport
+  /**  当前mcpServers对象集合。键为服务器名称，值为 McpServerConfig 或任意的 MCPTransport
    * 参考: https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling#initializing-an-mcp-client */
-  mcpServers: McpServerConfig[] = []
+  mcpServers: Record<string, McpServerConfig> = {}
   /** 当前ai-sdk的 mcpClient 数组 */
   mcpClients: any[] = []
   /** 当前 mcpClients 所对应的tools */
@@ -38,7 +38,7 @@ export class AgentModelProvider {
   messages: any[] = []
 
   constructor({ llmConfig, mcpServers, llm }: IAgentModelProviderOption) {
-    this.mcpServers = mcpServers || []
+    this.mcpServers = mcpServers || {}
 
     if (llm) {
       this.llm = llm
@@ -94,7 +94,7 @@ export class AgentModelProvider {
   private async _createMpcClients() {
     // 使用 Promise.all 并行处理所有 mcpServer 项
     this.mcpClients = await Promise.all(
-      this.mcpServers.map(async (server) => {
+      Object.values(this.mcpServers).map(async (server) => {
         return this._createOneClient(server)
       })
     )
@@ -139,32 +139,38 @@ export class AgentModelProvider {
   }
 
   /** 全量更新所有的 mcpServers */
-  async updateMcpServers(mcpServers?: McpServerConfig[]) {
+  async updateMcpServers(mcpServers?: Record<string, McpServerConfig>) {
     await this.closeAll()
     this.mcpServers = mcpServers || this.mcpServers
     await this.initClientsAndTools()
   }
 
   /** 插入一个新的mcpServer，如果已经存在则返回false */
-  async insertMcpServer(mcpServer: McpServerConfig) {
-    const find = this.mcpServers.find((item: any) => 'url' in item && 'url' in mcpServer && item.url === mcpServer.url)
-
-    if (!find) {
-      this.mcpServers = [...this.mcpServers, mcpServer]
-      const client = await this._createOneClient(mcpServer)
-      this.mcpClients.push(client)
-      this.mcpTools.push((await client?.tools?.()) as Record<string, any>)
-      this.onUpdatedTools?.()
-
-      return true
+  async insertMcpServer(serverName: string, mcpServer: McpServerConfig) {
+    // 检查是否已存在相同名称的服务器
+    if (this.mcpServers[serverName]) {
+      return false
     }
-    return false
-  }
-  /** 通过引用mcpServer变量，删除一组值： mcpServers mcpClients  mcpTools ignoreToolnames  */
-  async removeMcpServer(mcpServer: McpServerConfig) {
-    const index = this.mcpServers.findIndex((server) => server === mcpServer)
 
-    this.mcpServers.splice(index, 1)
+    this.mcpServers[serverName] = mcpServer
+    const client = await this._createOneClient(mcpServer)
+    this.mcpClients.push(client)
+    this.mcpTools.push((await client?.tools?.()) as Record<string, any>)
+    this.onUpdatedTools?.()
+
+    return true
+  }
+  /** 通过服务器名称删除mcpServer： mcpServers mcpClients  mcpTools ignoreToolnames  */
+  async removeMcpServer(serverName: string) {
+    if (!this.mcpServers[serverName]) {
+      return
+    }
+
+    // 找到对应的索引
+    const serverNames = Object.keys(this.mcpServers)
+    const index = serverNames.indexOf(serverName)
+
+    delete this.mcpServers[serverName]
 
     const delClient = this.mcpClients[index]
     this.mcpClients.splice(index, 1)

--- a/packages/next-sdk/agent/type.ts
+++ b/packages/next-sdk/agent/type.ts
@@ -25,6 +25,6 @@ export interface IAgentModelProviderOption {
   llm?: ProviderV2
   /** 代理模型提供器的大语言配置对象, 不能与 llm 同时传入 */
   llmConfig?: IAgentModelProviderLlmConfig
-  /** Mcp Server的配置对象的集合 */
-  mcpServers?: McpServerConfig[]
+  /** Mcp Server的配置对象的集合，键为服务器名称，值为配置对象 */
+  mcpServers?: Record<string, McpServerConfig>
 }


### PR DESCRIPTION
feat: 更新MCP服务器配置结构，支持以对象形式传入并优化相关文档说明

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Breaking Changes
  - MCP server configuration now uses a named mapping instead of an array.
  - Server operations now address servers by name (e.g., insert, update, remove).
  - Per-session server names are generated and used for loading and plugin association.
- Refactor
  - Components migrated to name-based MCP server management and initialization.
  - Iteration and indexing updated to align clients/tools with named servers.
- Documentation
  - Guides updated to show mapping-based configuration and require unique server names, with revised examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->