### PR TITLE
feat: Add browser extension related custom mcp-transport, and add proxy forwarding function in extension

### DIFF
--- a/packages/browser-extensions/src/main.js
+++ b/packages/browser-extensions/src/main.js
@@ -1,3 +1,126 @@
+/**
+ * Content Script 作为消息桥梁
+ * 负责在页面脚本（MCP Server）和 Sidepanel（MCP Client）之间转发 MCP 消息
+ * 使用 sessionId 进行消息路由
+ */
+
+// ============================================
+// 1. 监听来自页面脚本的消息（MCP Server → MCP Client）
+// ============================================
+window.addEventListener('message', (event) => {
+  // 验证消息来源（必须来自当前窗口）
+  if (event.source !== window) {
+    return
+  }
+
+  // 检查消息数据是否存在
+  if (!event.data || !event.data.type) {
+    return
+  }
+
+  // 处理 MCP Server 发送的消息，转发到 Sidepanel
+  if (event.data.type === 'mcp-server-to-client') {
+    if (!event.data.mcpMessage) {
+      console.error('[main.js] 消息缺少 mcpMessage 字段')
+      return
+    }
+
+    // 转发到 Sidepanel
+    chrome.runtime
+      .sendMessage({
+        type: 'mcp-server-to-client',
+        sessionId: event.data.sessionId,
+        mcpMessage: event.data.mcpMessage
+      })
+      .then(() => {
+        console.log('[main.js] ✅ 消息已转发到 Sidepanel')
+      })
+      .catch((error) => {
+        // 如果 Sidepanel 未打开，静默忽略
+        if (
+          !error.message.includes('message channel closed') &&
+          !error.message.includes('Receiving end does not exist')
+        ) {
+          console.error('[main.js] 转发消息失败:', error)
+        }
+      })
+  }
+
+  // 处理 MCP Server 注册消息，转发到 Sidepanel
+  if (event.data.type === 'mcp-server-register') {
+    if (!event.data.serverInfo) {
+      console.error('[main.js] 注册消息缺少 serverInfo 字段')
+      return
+    }
+
+    // 转发注册消息到 Sidepanel
+    chrome.runtime
+      .sendMessage({
+        type: 'mcp-server-register',
+        sessionId: event.data.sessionId,
+        serverInfo: event.data.serverInfo
+      })
+      .catch((error) => {
+        // 如果 Sidepanel 未打开，静默忽略
+        if (
+          !error.message.includes('message channel closed') &&
+          !error.message.includes('Receiving end does not exist')
+        ) {
+          console.error('[main.js] 转发注册失败:', error)
+        }
+      })
+  }
+})
+
+// ============================================
+// 2. 监听来自 Sidepanel 的消息（MCP Client → MCP Server）
+// ============================================
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  // 处理 Sidepanel 就绪消息（用于重新发现服务器）
+  if (message.type === 'sidepanel-ready') {
+    // 转发到页面脚本
+    window.postMessage(
+      {
+        type: 'sidepanel-ready',
+        timestamp: message.timestamp
+      },
+      window.location.origin
+    )
+
+    sendResponse({ success: true })
+    return true
+  }
+
+  // 处理 MCP Client 发送的消息，转发到页面脚本
+  if (message.type === 'mcp-client-to-server') {
+    if (!message.mcpMessage) {
+      console.error('[main.js] 消息缺少 mcpMessage 字段')
+      sendResponse({ success: false, error: '缺少 mcpMessage 字段' })
+      return true
+    }
+
+    try {
+      // 转发到页面脚本
+      window.postMessage(
+        {
+          type: 'mcp-client-to-server',
+          sessionId: message.sessionId,
+          mcpMessage: message.mcpMessage
+        },
+        window.location.origin
+      )
+
+      console.log('[main.js] ✅ 消息已转发到页面')
+      sendResponse({ success: true })
+    } catch (error) {
+      console.error('[main.js] 转发失败:', error)
+      sendResponse({ success: false, error: error.message })
+    }
+  }
+
+  return true
+})
+
 const initWebMCP = () => {
   const urlToolsMap = {
     'https://opentiny.design': chrome.runtime.getURL('src/mcp-servers/opentiny.design/index.js')

--- a/packages/next-sdk/WebMcp.ts
+++ b/packages/next-sdk/WebMcp.ts
@@ -16,3 +16,6 @@ export type * from '@modelcontextprotocol/sdk/shared/transport.js'
 export type * from '@modelcontextprotocol/sdk/client/sse.js'
 export type * from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 export type * from '@modelcontextprotocol/sdk/server/mcp.js'
+
+export * from './transport/ExtensionClientTransport'
+export * from './transport/ExtensionServerTransport'

--- a/packages/next-sdk/index.ts
+++ b/packages/next-sdk/index.ts
@@ -20,6 +20,10 @@ export type * from '@modelcontextprotocol/sdk/server/mcp.js'
 export * from './WebMcpServer'
 export * from './WebMcpClient'
 
+// 浏览器扩展自定义传输层
+export * from './transport/ExtensionClientTransport'
+export * from './transport/ExtensionServerTransport'
+
 // 快速创建一个悬浮图标和菜单，是扫码和聊天框的入口
 export { createRemoter } from './remoter/createRemoter'
 

--- a/packages/next-sdk/transport/ExtensionClientTransport.ts
+++ b/packages/next-sdk/transport/ExtensionClientTransport.ts
@@ -1,0 +1,201 @@
+import type { Transport, TransportSendOptions } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { type JSONRPCMessage, JSONRPCMessageSchema } from '@modelcontextprotocol/sdk/types.js'
+
+// Chrome 扩展 API 类型声明
+declare const chrome: any
+
+/**
+ * Chrome 扩展客户端 Transport
+ * 用于 Sidepanel 中的 MCP Client
+ * 实现标准的 MCP Transport 接口
+ *
+ * 使用 targetSessionId 连接到特定的 Server
+ */
+export class ExtensionClientTransport implements Transport {
+  // MCP Transport 必需的回调
+  onmessage?: (message: JSONRPCMessage) => void // 接收到消息时的回调
+  onerror?: (error: Error) => void // 发生错误时的回调
+  onclose?: () => void // 连接关闭时的回调
+
+  // 目标 sessionId，用于连接到特定的 Server（必需参数）
+  readonly targetSessionId: string
+
+  // 会话ID，用于标识此 transport 实例
+  readonly sessionId: string
+
+  // 内部状态
+  private _messageListener: ((message: any, sender: any, sendResponse: any) => boolean) | null = null // 消息监听器引用
+  private _isStarted: boolean = false // 是否已启动
+  private _isClosed: boolean = false // 是否已关闭
+
+  constructor(targetSessionId: string) {
+    // 目标 sessionId，用于连接到特定的 Server（必需参数）
+    if (!targetSessionId) {
+      throw new Error('targetSessionId is required for ExtensionClientTransport')
+    }
+
+    this.targetSessionId = targetSessionId
+
+    // 会话ID，用于标识此 transport 实例
+    this.sessionId = `client-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
+  }
+
+  /**
+   * 启动 transport，开始监听消息
+   * @returns {Promise<void>}
+   */
+  async start() {
+    // 防止重复启动
+    if (this._isStarted) {
+      return
+    }
+
+    if (this._isClosed) {
+      throw new Error('Transport 已关闭，无法重新启动')
+    }
+
+    try {
+      // 创建消息监听器
+      this._messageListener = (message, sender, sendResponse) => {
+        // 只处理来自目标 sessionId 的 MCP 消息
+        if (message.type === 'mcp-server-to-client') {
+          // 检查 sessionId 是否匹配
+          if (message.sessionId !== this.targetSessionId) {
+            console.log('[ExtensionClientTransport] sessionId 不匹配，忽略')
+            return true
+          }
+
+          if (!message.mcpMessage) {
+            console.error('[ExtensionClientTransport] 消息缺少 mcpMessage 字段')
+            return true
+          }
+
+          try {
+            // 调用 MCP Client 的消息处理器
+            if (this.onmessage) {
+              const mcpMessage = JSONRPCMessageSchema.parse(message.mcpMessage)
+              this.onmessage(mcpMessage)
+            } else {
+              console.warn('[ExtensionClientTransport] onmessage 回调未设置')
+            }
+          } catch (error) {
+            console.error('[ExtensionClientTransport] 处理消息时发生错误:', error)
+            if (this.onerror) {
+              this.onerror(error instanceof Error ? error : new Error(String(error)))
+            }
+          }
+        }
+
+        return true // 保持消息通道打开（异步响应）
+      }
+
+      // 注册消息监听器
+      chrome.runtime.onMessage.addListener(this._messageListener)
+
+      this._isStarted = true
+    } catch (error) {
+      console.error('[ExtensionClientTransport] 启动失败:', error)
+      if (this.onerror) {
+        this.onerror(error instanceof Error ? error : new Error(String(error)))
+      }
+      throw error
+    }
+  }
+
+  /**
+   * 发送消息到 MCP Server
+   * @param {Object} message - JSONRPC 消息对象
+   * @returns {Promise<void>}
+   */
+  async send(message: JSONRPCMessage, _options?: TransportSendOptions): Promise<void> {
+    // 检查状态
+    if (!this._isStarted) {
+      const error = new Error('Transport 未启动，无法发送消息')
+      console.error('[ExtensionClientTransport]', error.message)
+      if (this.onerror) {
+        this.onerror(error)
+      }
+      throw error
+    }
+
+    if (this._isClosed) {
+      const error = new Error('Transport 已关闭，无法发送消息')
+      console.error('[ExtensionClientTransport]', error.message)
+      if (this.onerror) {
+        this.onerror(error)
+      }
+      throw error
+    }
+
+    try {
+      // 向所有标签页广播消息（因为不知道 Server 在哪个标签页）
+      // 每个页面的 content script 会根据 sessionId 路由到正确的 Server
+      const tabs = await chrome.tabs.query({})
+      console.log('[ExtensionClientTransport] 向', tabs.length, '个标签页广播消息')
+
+      let sent = false
+      for (const tab of tabs) {
+        if (tab.id) {
+          chrome.tabs
+            .sendMessage(tab.id, {
+              type: 'mcp-client-to-server',
+              sessionId: this.targetSessionId,
+              mcpMessage: message
+            })
+            .then(() => {
+              if (!sent) {
+                sent = true
+                console.log('[ExtensionClientTransport] ✅ 消息已发送到标签页:', tab.id)
+              }
+            })
+            .catch((error: Error) => {
+              // 某些标签页没有 content script，忽略
+              if (!error.message.includes('Receiving end does not exist')) {
+                console.error('[ExtensionClientTransport] 发送到标签页', tab.id, '失败:', error)
+              }
+            })
+        }
+      }
+    } catch (error) {
+      console.error('[ExtensionClientTransport] 发送消息失败:', error)
+      const wrappedError = error instanceof Error ? error : new Error(String(error))
+      if (this.onerror) {
+        this.onerror(wrappedError)
+      }
+      throw wrappedError
+    }
+  }
+
+  /**
+   * 关闭 transport
+   * @returns {Promise<void>}
+   */
+  async close() {
+    // 防止重复关闭
+    if (this._isClosed) {
+      return
+    }
+
+    try {
+      // 移除消息监听器
+      if (this._messageListener) {
+        chrome.runtime.onMessage.removeListener(this._messageListener)
+        this._messageListener = null
+      }
+
+      this._isClosed = true
+      this._isStarted = false
+
+      // 触发关闭回调
+      if (this.onclose) {
+        this.onclose()
+      }
+    } catch (error) {
+      console.error('[ExtensionClientTransport] 关闭时发生错误:', error)
+      if (this.onerror) {
+        this.onerror(error instanceof Error ? error : new Error(String(error)))
+      }
+      throw error
+    }
+  }
+}

--- a/packages/next-sdk/transport/ExtensionServerTransport.ts
+++ b/packages/next-sdk/transport/ExtensionServerTransport.ts
@@ -1,0 +1,286 @@
+import type { Transport, TransportSendOptions } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { type JSONRPCMessage, JSONRPCMessageSchema } from '@modelcontextprotocol/sdk/types.js'
+
+declare const window: Window & typeof globalThis
+declare const document: Document
+
+/**
+ * 服务器注册信息接口
+ */
+export interface ServerInfo {
+  /**
+   * 服务器名称
+   */
+  name: string
+
+  /**
+   * 服务器版本
+   */
+  version: string
+
+  /**
+   * 服务器描述（可选）
+   */
+  description?: string
+
+  /**
+   * 服务器 URL（由 transport 自动添加）
+   */
+  url?: string
+
+  /**
+   * 页面标题（由 transport 自动添加）
+   */
+  title?: string
+}
+
+/**
+ * Chrome 扩展服务端 Transport
+ * 用于页面脚本中的 MCP Server（通过 content script 作为桥梁）
+ * 实现标准的 MCP Transport 接口
+ *
+ * 使用 sessionId 进行消息路由
+ * 支持固定 sessionId，避免页面刷新时 sessionId 改变
+ */
+export class ExtensionServerTransport implements Transport {
+  // MCP Transport 必需的回调
+  onmessage?: (message: JSONRPCMessage) => void // 接收到消息时的回调
+  onerror?: (error: Error) => void // 发生错误时的回调
+  onclose?: () => void // 连接关闭时的回调
+
+  // 会话ID，用于标识此 transport 实例并路由消息
+  readonly sessionId: string
+
+  // 内部状态
+  private _messageListener: ((event: MessageEvent) => void) | null = null // 消息监听器引用
+  private _isStarted: boolean = false // 是否已启动
+  private _isClosed: boolean = false // 是否已关闭
+  private _lastRegistration: ServerInfo | null = null // 最后一次注册信息（用于 Sidepanel 刷新后重新注册）
+
+  constructor(sessionId: string | null = null) {
+    // 会话ID，用于标识此 transport 实例并路由消息
+    // 如果提供了 sessionId，使用提供的；否则随机生成
+    if (sessionId) {
+      this.sessionId = sessionId
+    } else {
+      this.sessionId = `server-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
+    }
+
+    // 设置监听器
+    this._setupMessageListener()
+  }
+
+  /**
+   * 设置消息监听器
+   */
+  private _setupMessageListener(): void {
+    const listener = (event: MessageEvent) => {
+      // 只处理来自当前窗口的消息
+      if (event.source !== window) {
+        return
+      }
+
+      // 处理 sidepanel-ready 消息（Sidepanel 刷新后的重新发现）
+      if (event.data?.type === 'sidepanel-ready') {
+        // 如果已经有注册信息，重新发送
+        if (this._lastRegistration && this._isStarted) {
+          this.notifyRegistration(this._lastRegistration).catch((error) => {
+            console.error('[ExtensionServerTransport] 重新注册失败:', error)
+          })
+        }
+      }
+    }
+
+    window.addEventListener('message', listener)
+  }
+
+  /**
+   * 启动 transport，开始监听消息
+   * @returns {Promise<void>}
+   */
+  async start() {
+    // 防止重复启动
+    if (this._isStarted) {
+      return
+    }
+
+    if (this._isClosed) {
+      throw new Error('Transport 已关闭，无法重新启动')
+    }
+
+    try {
+      // 创建消息监听器（监听来自 content script 的消息）
+      this._messageListener = (event) => {
+        // 验证消息来源（必须来自当前窗口）
+        if (event.source !== window) {
+          return
+        }
+
+        // 检查消息数据是否存在
+        if (!event.data || !event.data.type) {
+          return
+        }
+
+        // 只处理发送给此 sessionId 的 MCP Client 消息
+        if (event.data.type === 'mcp-client-to-server') {
+          // 检查 sessionId 是否匹配
+          if (event.data.sessionId !== this.sessionId) {
+            // 不是发给这个 server 的，忽略
+            return
+          }
+
+          if (!event.data.mcpMessage) {
+            console.error('[ExtensionServerTransport] 消息缺少 mcpMessage 字段')
+            return
+          }
+
+          try {
+            // 调用 MCP Server 的消息处理器
+            if (this.onmessage) {
+              const mcpMessage = JSONRPCMessageSchema.parse(event.data.mcpMessage)
+              this.onmessage(mcpMessage)
+              console.log('[ExtensionServerTransport] ✅ 消息已处理')
+            } else {
+              console.warn('[ExtensionServerTransport] onmessage 回调未设置')
+            }
+          } catch (error) {
+            console.error('[ExtensionServerTransport] 处理消息时发生错误:', error)
+            if (this.onerror) {
+              this.onerror(error instanceof Error ? error : new Error(String(error)))
+            }
+          }
+        }
+      }
+
+      // 注册消息监听器
+      window.addEventListener('message', this._messageListener)
+
+      this._isStarted = true
+    } catch (error) {
+      console.error('[ExtensionServerTransport] 启动失败:', error)
+      if (this.onerror) {
+        this.onerror(error instanceof Error ? error : new Error(String(error)))
+      }
+      throw error
+    }
+  }
+
+  /**
+   * 发送消息到 MCP Client
+   * @param {Object} message - JSONRPC 消息对象
+   * @returns {Promise<void>}
+   */
+  async send(message: JSONRPCMessage, _options?: TransportSendOptions): Promise<void> {
+    // 检查状态
+    if (!this._isStarted) {
+      const error = new Error('Transport 未启动，无法发送消息')
+      console.error('[ExtensionServerTransport]', error.message)
+      if (this.onerror) {
+        this.onerror(error)
+      }
+      throw error
+    }
+
+    if (this._isClosed) {
+      const error = new Error('Transport 已关闭，无法发送消息')
+      console.error('[ExtensionServerTransport]', error.message)
+      if (this.onerror) {
+        this.onerror(error)
+      }
+      throw error
+    }
+
+    try {
+      // 通过 window.postMessage 发送到 content script
+      // 使用 window.location.origin 确保只发送到同源
+      // 携带 sessionId 以便正确路由到对应的 client
+      window.postMessage(
+        {
+          type: 'mcp-server-to-client',
+          sessionId: this.sessionId,
+          mcpMessage: message
+        },
+        window.location.origin
+      )
+      console.log('[ExtensionServerTransport] ✅ 响应已发送')
+    } catch (error) {
+      console.error('[ExtensionServerTransport] 发送消息失败:', error)
+      const wrappedError = error instanceof Error ? error : new Error(String(error))
+      if (this.onerror) {
+        this.onerror(wrappedError)
+      }
+      throw wrappedError
+    }
+  }
+
+  /**
+   * 通知 Sidepanel 此 Server 已启动并准备接受连接
+   * @param {Object} serverInfo - 服务器信息
+   * @param {string} serverInfo.name - 服务器名称
+   * @param {string} serverInfo.version - 服务器版本
+   * @param {string} [serverInfo.description] - 服务器描述
+   * @returns {Promise<void>}
+   */
+  async notifyRegistration(serverInfo: ServerInfo): Promise<void> {
+    if (!this._isStarted) {
+      console.warn('[ExtensionServerTransport] Transport 未启动，无法发送注册通知')
+      return
+    }
+
+    // 保存注册信息，用于 Sidepanel 刷新后重新注册
+    this._lastRegistration = serverInfo
+
+    try {
+      window.postMessage(
+        {
+          type: 'mcp-server-register',
+          sessionId: this.sessionId,
+          serverInfo: {
+            ...serverInfo,
+            url: window.location.href,
+            title: document.title
+          }
+        },
+        window.location.origin
+      )
+    } catch (error) {
+      console.error('[ExtensionServerTransport] 发送注册通知失败:', error)
+      if (this.onerror) {
+        this.onerror(error instanceof Error ? error : new Error(String(error)))
+      }
+    }
+  }
+
+  /**
+   * 关闭 transport
+   * @returns {Promise<void>}
+   */
+  async close() {
+    // 防止重复关闭
+    if (this._isClosed) {
+      return
+    }
+
+    try {
+      // 移除消息监听器
+      if (this._messageListener) {
+        window.removeEventListener('message', this._messageListener)
+        this._messageListener = null
+      }
+
+      this._isClosed = true
+      this._isStarted = false
+
+      // 触发关闭回调
+      if (this.onclose) {
+        this.onclose()
+      }
+    } catch (error) {
+      console.error('[ExtensionServerTransport] 关闭时发生错误:', error)
+      if (this.onerror) {
+        this.onerror(error instanceof Error ? error : new Error(String(error)))
+      }
+      throw error
+    }
+  }
+}


### PR DESCRIPTION
feat: 添加浏览器扩展相关自定义mcp-transport，并添加扩展中的代理转发功能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Chrome extension transport layer enabling MCP messaging between page context and sidebar panel
  * Enables bidirectional message routing with session management
  * Added server registration capabilities for initializing web-based MCP servers within browser extensions
  * Supports resilient communication with automatic recovery after panel refresh

<!-- end of auto-generated comment: release notes by coderabbit.ai -->