### PR TITLE
feat: unified llmConfig configuration, resolved the issue of model configuration not being passed when passing llm configuration items to the remote, and modified the corresponding documentation.

### DIFF
--- a/docs/guide/api-agentModelProvider.md
+++ b/docs/guide/api-agentModelProvider.md
@@ -15,43 +15,45 @@ AgentModelProvider 类是对 ai-sdk Provider 一个简单封装，通过它可�
 ```typescript
 /** 代理模型提供器的大语言配置对象 */
 export interface IAgentModelProviderLlmConfig {
-  apiKey: string
-  baseURL: string
+  apiKey?: string
+  baseURL?: string
   /** 支持内置的常用模型，或者传入一个ai-sdk官方的Provider工厂函数
    * @example
    * import { createOpenAI } from '@ai-sdk/openai'
    */
-  providerType: 'openai' | 'deepseek' | ((options: any) => ProviderV2)
+  providerType?: 'openai' | 'deepseek' | ((options: any) => ProviderV2)
+  /** 直接传入 ai-sdk Provider 实例，优先级最高 */
+  llm?: ProviderV2
 }
 
 export interface IAgentModelProviderOption {
-  /** ai-sdk官方的Provider实例，不能与 llmConfig 同时传入
-   * @example
-   * import { openai } from '@ai-sdk/openai'
-   */
-  llm?: ProviderV2
-  /** 代理模型提供器的大语言配置对象, 不能与 llm 同时传入 */
-  llmConfig?: IAgentModelProviderLlmConfig
+  /** 代理模型提供器的大语言配置对象 */
+  llmConfig: IAgentModelProviderLlmConfig
   /** Mcp Server的配置对象的集合，键为服务器名称，值为配置对象 */
   mcpServers?: Record<string, McpServerConfig>
 }
 ```
 
-其中 `llm` 与 `llmConfig` 都是定义如何连接大模型，使用其中之一即可
+`llmConfig` 统一承载了所有 LLM 连接方式，优先级为 `llmConfig.llm` > `llmConfig.providerType`。根据需要选择以下方式：
 
-1. 通过 `llm` 来定义连接
+1. **通过 `llmConfig.llm` 传入自定义 Provider 实例**
 
 ```typescript
-import { openAI } from '@ai-sdk/openai'
+import { createOpenAI } from '@ai-sdk/openai'
 
 const webAgent = new AgentModelProvider({
-  llm: openAI
+  llmConfig: {
+    llm: createOpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+      baseURL: 'https://api.openai.com/v1'
+    })
+  }
 })
 ```
 
-这种形式可以隐藏`apiKey`等敏感信息，通常是由环境变量来提供。 如何设置环境变量，请参考`ai-sdk Provider`的相关文档页面
+这种形式可以隐藏 `apiKey` 等敏感信息，通常通过环境变量创建 Provider。
 
-2. 通过 `llmConfig` 来定义连接
+2. **通过 `llmConfig.providerType` 来定义连接**
 
 ```typescript
 const webAgent = new AgentModelProvider({

--- a/docs/guide/api-agentModelProvider.md
+++ b/docs/guide/api-agentModelProvider.md
@@ -13,18 +13,20 @@ AgentModelProvider 类是对 ai-sdk Provider 一个简单封装，通过它可�
 `AgentModelProvider` 是一个 Class, 它的构造函数入参为：
 
 ```typescript
-/** 代理模型提供器的大语言配置对象 */
-export interface IAgentModelProviderLlmConfig {
-  apiKey?: string
-  baseURL?: string
-  /** 支持内置的常用模型，或者传入一个ai-sdk官方的Provider工厂函数
-   * @example
-   * import { createOpenAI } from '@ai-sdk/openai'
-   */
-  providerType?: 'openai' | 'deepseek' | ((options: any) => ProviderV2)
-  /** 直接传入 ai-sdk Provider 实例，优先级最高 */
-  llm?: ProviderV2
+type ProviderFactoryConfig = {
+  apiKey: string
+  baseURL: string
+  /** 支持内置的常用模型，或者传入一个ai-sdk官方的Provider工厂函数 */
+  providerType: 'openai' | 'deepseek' | ((options: any) => ProviderV2)
 }
+
+type ProviderInstanceConfig = {
+  /** 直接传入 ai-sdk Provider 实例，优先级最高 */
+  llm: ProviderV2
+}
+
+/** 代理模型提供器的大语言配置对象（二选一） */
+export type IAgentModelProviderLlmConfig = ProviderFactoryConfig | ProviderInstanceConfig
 
 export interface IAgentModelProviderOption {
   /** 代理模型提供器的大语言配置对象 */

--- a/docs/guide/tiny-robot-remoter.md
+++ b/docs/guide/tiny-robot-remoter.md
@@ -34,7 +34,7 @@ import { TinyRemoter } from '@opentiny/next-remoter'
 - `qrCodeUrl` 二维码URL，用于显示在遥控器模式下，点击遥控器图标后，弹出二维码对应的链接 url。
 - `menuItems` 菜单项配置数组，用于显示在遥控器模式下，点击遥控器图标后，显示的菜单项。具体配置项见 [api-createRemoter](./api-createRemoter.md)
 - `systemPrompt` 对话llm 时，传入的 system message: system-prompt=你是一个智能助手，工作地点是深圳
-- `llmConfig` 大语言模型配置对象，支持配置 `apiKey`、`baseURL` 、 `model` 、`maxSteps` 、 `providerType` 、 `providerOptions`、`extraTools`，也可以直接通过 `llmConfig.llm` 传入自定义 Provider，优先级最高
+- `llmConfig` 大语言模型配置对象，支持配置 `apiKey`、`baseURL` 、 `model` 、`maxSteps` 、 `providerType` 、 `providerOptions`、`extraTools`，其中 `apiKey/baseURL/providerType` 与 `llmConfig.llm` 二选一
 - `inBrowserExt` 设置组件运行在普通页面还是浏览器的扩展中，默认值为：false
 - `genUiAble` 设置是否支持生成式UI的渲染
 - `genUiComponents` 生成式UI内置了一批组件，如果需要引入新组件，需要通过这里导入。 参考示例： shallowReactive({TinyUser, TinyAlert })
@@ -42,19 +42,25 @@ import { TinyRemoter } from '@opentiny/next-remoter'
 ### llmConfig 配置详情
 
 ```typescript
-interface ICustomAgentModelProviderLlmConfig {
+type ProviderFactoryConfig = {
   /** API密钥 */
-  apiKey?: string
+  apiKey: string
   /** API基础URL */
-  baseURL?: string
+  baseURL: string
   /** 提供商类型，支持 'openai' | 'deepseek' 或自定义Provider函数 */
-  providerType?: 'openai' | 'deepseek' | ((options: any) => ProviderV2)
+  providerType: 'openai' | 'deepseek' | ((options: any) => ProviderV2)
+}
+
+type ProviderInstanceConfig = {
   /** 直接传入 ai-sdk Provider 实例，优先级最高 */
-  llm?: ProviderV2
+  llm: ProviderV2
+}
+
+type ICustomAgentModelProviderLlmConfig = (ProviderFactoryConfig | ProviderInstanceConfig) & {
   /** 模型名称 */
   model: string
-  /** 工具调用最大步数 */
-  maxSteps: number
+  /** 工具调用最大步数，默认为15 */
+  maxSteps?: number
   /** Provider 额外参数 */
   providerOptions?: Record<string, any>
   /** 额外自定义工具 */

--- a/docs/guide/tiny-robot-remoter.md
+++ b/docs/guide/tiny-robot-remoter.md
@@ -34,8 +34,7 @@ import { TinyRemoter } from '@opentiny/next-remoter'
 - `qrCodeUrl` 二维码URL，用于显示在遥控器模式下，点击遥控器图标后，弹出二维码对应的链接 url。
 - `menuItems` 菜单项配置数组，用于显示在遥控器模式下，点击遥控器图标后，显示的菜单项。具体配置项见 [api-createRemoter](./api-createRemoter.md)
 - `systemPrompt` 对话llm 时，传入的 system message: system-prompt=你是一个智能助手，工作地点是深圳
-- `llmConfig` 大语言模型配置对象，不能与 `llm` 同时传入。支持配置 `apiKey`、`baseURL` 、 `model` 、`maxSteps` 、 `providerType` 、 `providerOptions` 和 `extraTools`
-- `llm` ai-sdk官方的Provider实例，不能与 `llmConfig` 同时传入。可以传入自定义的Provider实例
+- `llmConfig` 大语言模型配置对象，支持配置 `apiKey`、`baseURL` 、 `model` 、`maxSteps` 、 `providerType` 、 `providerOptions`、`extraTools`，也可以直接通过 `llmConfig.llm` 传入自定义 Provider，优先级最高
 - `inBrowserExt` 设置组件运行在普通页面还是浏览器的扩展中，默认值为：false
 - `genUiAble` 设置是否支持生成式UI的渲染
 - `genUiComponents` 生成式UI内置了一批组件，如果需要引入新组件，需要通过这里导入。 参考示例： shallowReactive({TinyUser, TinyAlert })
@@ -45,36 +44,46 @@ import { TinyRemoter } from '@opentiny/next-remoter'
 ```typescript
 interface ICustomAgentModelProviderLlmConfig {
   /** API密钥 */
-  apiKey: string
+  apiKey?: string
   /** API基础URL */
-  baseURL: string
+  baseURL?: string
   /** 提供商类型，支持 'openai' | 'deepseek' 或自定义Provider函数 */
-  providerType: 'openai' | 'deepseek' | ((options: any) => ProviderV2)
+  providerType?: 'openai' | 'deepseek' | ((options: any) => ProviderV2)
+  /** 直接传入 ai-sdk Provider 实例，优先级最高 */
+  llm?: ProviderV2
   /** 模型名称 */
   model: string
   /** 工具调用最大步数 */
   maxSteps: number
+  /** Provider 额外参数 */
+  providerOptions?: Record<string, any>
+  /** 额外自定义工具 */
+  extraTools?: Record<string, any>
 }
 ```
 
-### llm Provider 实例
+### 通过 llmConfig.llm 使用自定义 Provider
 
-`llm` 参数接受任何符合 ai-sdk Provider 规范的实例，例如：
+`llmConfig.llm` 可以接受任何符合 ai-sdk Provider 规范的实例，例如：
 
 ```typescript
 import { createOpenAI } from '@ai-sdk/openai'
 import { createAnthropic } from '@ai-sdk/anthropic'
 
-// OpenAI Provider
-const openaiProvider = createOpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-  baseURL: 'https://api.openai.com/v1'
-})
+const llmConfig = {
+  // OpenAI Provider
+  llm: createOpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+    baseURL: 'https://api.openai.com/v1'
+  })
+}
 
-// Anthropic Provider
-const anthropicProvider = createAnthropic({
-  apiKey: process.env.ANTHROPIC_API_KEY
-})
+const claudeConfig = {
+  // Anthropic Provider
+  llm: createAnthropic({
+    apiKey: process.env.ANTHROPIC_API_KEY
+  })
+}
 ```
 
 ## 插槽
@@ -171,7 +180,7 @@ const llmConfig = {
     sessionId="your-session-id"
     title="我的AI助手"
     systemPrompt="你是一个智能助手"
-    :llm="customProvider"
+    :llmConfig="llmConfig"
   />
 </template>
 
@@ -183,10 +192,12 @@ import { createOpenAI } from '@ai-sdk/openai'
 const show = ref(false)
 
 // 使用自定义Provider实例
-const customProvider = createOpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-  baseURL: 'https://api.openai.com/v1'
-})
+const llmConfig = {
+  llm: createOpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+    baseURL: 'https://api.openai.com/v1'
+  })
+}
 </script>
 ```
 
@@ -229,7 +240,7 @@ const deepSeekConfig = {
     sessionId="your-session-id"
     title="我的AI助手"
     systemPrompt="你是一个智能助手"
-    :llm="anthropicProvider"
+    :llmConfig="anthropicConfig"
   />
 </template>
 
@@ -241,9 +252,11 @@ import { createAnthropic } from '@ai-sdk/anthropic'
 const show = ref(false)
 
 // 使用Anthropic Provider
-const anthropicProvider = createAnthropic({
-  apiKey: process.env.ANTHROPIC_API_KEY
-})
+const anthropicConfig = {
+  llm: createAnthropic({
+    apiKey: process.env.ANTHROPIC_API_KEY
+  })
+}
 </script>
 ```
 

--- a/docs/guide/use-next-agent.md
+++ b/docs/guide/use-next-agent.md
@@ -33,10 +33,8 @@ const {
 
 ```typescript
 export type INextAgetOption = {
-  /** ai-sdk官方的Provider实例，不能与 llmConfig 同时传入 */
-  llm?: ProviderV2
-  /** 代理模型提供器的大语言配置对象, 不能与 llm 同时传入 */
-  llmConfig?: IAgentModelProviderLlmConfig
+  /** 代理模型提供器的大语言配置对象，llmConfig.llm 优先级最高 */
+  llmConfig: IAgentModelProviderLlmConfig
   /** 访问 llm 时，预置的系统提示词 */
   systemPrompt?: string
   /** 大语言模型 的 modelId， 比如：'deepseek-ai/DeepSeek-V3' */
@@ -56,7 +54,7 @@ export type INextAgetOption = {
 }
 ```
 
-- llm 与 llmConfig 都是`LLM`的配置信息，二者填写一个即可。
+- llmConfig 统一承载所有 `LLM` 连接方式，可通过 `llmConfig.llm` 或 `llmConfig.providerType` 定义具体 Provider。
 - systemPrompt,model,maxStep 都是与`LLM`对话时的基本配置。
 - agentRoot 与 sessionId 都是配置智能化WEB应用的信息。 `sessionId` 可以不填写，后面通过 `addSessionId` 来添加待操控的WEB应用。
 - ui ：当前函数内置的流行Chat UI库的支持，能返回正确的 `messages` 的会话数据。

--- a/packages/next-remoter/README.md
+++ b/packages/next-remoter/README.md
@@ -78,9 +78,9 @@ createRemoter({
 
 ## LLM配置
 
-TinyRemoter组件支持自定义大语言模型配置，有两种方式：
+TinyRemoter组件支持自定义大语言模型配置，统一通过 `llmConfig` 传入：
 
-### 1. 使用llmConfig配置对象
+### 1. 使用 llmConfig.providerType 配置对象
 
 ```typescript
 const llmConfig = {
@@ -90,7 +90,7 @@ const llmConfig = {
 }
 ```
 
-### 2. 使用自定义Provider实例
+### 2. 使用自定义Provider实例（通过 llmConfig.llm）
 
 ```typescript
 import { createOpenAI } from '@ai-sdk/openai'
@@ -99,13 +99,17 @@ const customProvider = createOpenAI({
   apiKey: process.env.OPENAI_API_KEY,
   baseURL: 'https://api.openai.com/v1'
 })
+
+const llmConfig = {
+  llm: customProvider
+}
 ```
 
 然后在组件中使用：
 
 ```html
 <tiny-remoter 
-  :llm="customProvider"
+  :llmConfig="llmConfig"
   :sessionId="sessionId" 
 />
 ```

--- a/packages/next-remoter/components.d.ts
+++ b/packages/next-remoter/components.d.ts
@@ -11,7 +11,6 @@ declare module 'vue' {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     TinyRobotChat: typeof import('./src/components/tiny-robot-chat.vue')['default']
-    TinyUser: typeof import('./src/components/TinyUser.vue')['default']
     VanIcon: typeof import('vant/es')['Icon']
   }
 }

--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-remoter",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "type": "module",
   "files": [
     "dist"

--- a/packages/next-remoter/src/components/tiny-robot-chat.vue
+++ b/packages/next-remoter/src/components/tiny-robot-chat.vue
@@ -192,14 +192,9 @@ const props = defineProps({
     type: String,
     default: 'remoter'
   },
-  /** 大语言模型配置对象，不能与 llm 同时传入 */
+  /** 大语言模型配置对象 */
   llmConfig: {
     type: Object as () => ICustomAgentModelProviderLlmConfig | undefined,
-    default: undefined
-  },
-  /** ai-sdk官方的Provider实例，不能与 llmConfig 同时传入 */
-  llm: {
-    type: Object,
     default: undefined
   },
   /** 设置组件运行在普通页面还是浏览器的扩展中 */
@@ -292,8 +287,7 @@ const {
   sessionId: toRef(props, 'sessionId'),
   agentRoot: toRef(props, 'agentRoot'),
   systemPrompt: props.systemPrompt || '',
-  llmConfig: props.llmConfig,
-  llm: props.llm
+  llmConfig: props.llmConfig
 })
 
 /**

--- a/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
+++ b/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
@@ -11,11 +11,10 @@ import type { ICustomAgentModelProviderLlmConfig, StreamPart } from '../types/ty
 // 配置常量
 const DEFAULT_CONFIG: ICustomAgentModelProviderLlmConfig = {
   apiKey: 'sk-trial',
-  baseURL: 'https://agent.opentiny.design/api/v1/ai/prompt/',
+  baseURL: 'https://agent.opentiny.design/api/v1/ai',
   providerType: 'deepseek',
   model: 'deepseek-ai/DeepSeek-V3',
   maxSteps: 15,
-  providerOptions: {},
   extraTools: {}
 }
 
@@ -25,34 +24,31 @@ export class CustomAgentModelProvider extends BaseModelProvider {
   /** 一个 ai-sdk agent 封装 */
   agent: AgentModelProvider
   systemPrompt: string
-  llmConfig = DEFAULT_CONFIG
+  llmConfig: ICustomAgentModelProviderLlmConfig = DEFAULT_CONFIG
 
   constructor(
     config: AIModelConfig,
     sessionId: Ref<string>,
     agentRoot: Ref<string>,
     systemPrompt: string,
-    llmConfig?: ICustomAgentModelProviderLlmConfig,
-    llm?: any
+    llmConfig?: ICustomAgentModelProviderLlmConfig
   ) {
     super(config)
 
-    // 构建AgentModelProvider的选项
-    const options: IAgentModelProviderOption = {
-      mcpServers: this.createMcpServers(sessionId.value, agentRoot.value)
+    const mergedConfig: ICustomAgentModelProviderLlmConfig = {
+      ...DEFAULT_CONFIG,
+      ...(llmConfig || {})
     }
 
-    // 优先使用传入的llm实例，其次使用llmConfig，最后使用默认配置
-    if (llm) {
-      options.llm = llm
-    } else {
-      if (llmConfig) {
-        this.llmConfig = Object.assign(DEFAULT_CONFIG, llmConfig)
-      }
-      options.llmConfig = {
-        apiKey: this.llmConfig.apiKey,
-        baseURL: this.llmConfig.baseURL,
-        providerType: this.llmConfig.providerType
+    this.llmConfig = mergedConfig
+
+    const options: IAgentModelProviderOption = {
+      mcpServers: this.createMcpServers(sessionId.value, agentRoot.value),
+      llmConfig: {
+        apiKey: mergedConfig.apiKey,
+        baseURL: mergedConfig.baseURL,
+        providerType: mergedConfig.providerType,
+        llm: mergedConfig.llm
       }
     }
 
@@ -201,7 +197,7 @@ export class CustomAgentModelProvider extends BaseModelProvider {
       abortSignal: request.options?.signal,
       tools: { ['get-today']: getToday, ...(this.llmConfig.extraTools || {}) },
       maxSteps: this.llmConfig.maxSteps,
-      providerOptions: this.llmConfig.providerOptions || {},
+      providerOptions: this.llmConfig.providerOptions,
       onFinish: async () => {
         await this.agent.closeAll()
         handler.onDone()

--- a/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
+++ b/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
@@ -8,14 +8,16 @@ import { AgentModelProvider, McpServerConfig, IAgentModelProviderOption } from '
 import { getToday } from './tools'
 import type { ICustomAgentModelProviderLlmConfig, StreamPart } from '../types/type'
 
-// 配置常量
-const DEFAULT_CONFIG: ICustomAgentModelProviderLlmConfig = {
-  apiKey: 'sk-trial',
-  baseURL: 'https://agent.opentiny.design/api/v1/ai',
-  providerType: 'deepseek',
+const DEFAULT_SHARED_CONFIG = {
   model: 'deepseek-ai/DeepSeek-V3',
   maxSteps: 15,
   extraTools: {}
+}
+
+const DEFAULT_FACTORY_CONFIG = {
+  apiKey: 'sk-trial',
+  baseURL: 'https://agent.opentiny.design/api/v1/ai',
+  providerType: 'deepseek' as const
 }
 
 /** Tiny-robot 所需要的自定义大语言的Provider */
@@ -24,7 +26,7 @@ export class CustomAgentModelProvider extends BaseModelProvider {
   /** 一个 ai-sdk agent 封装 */
   agent: AgentModelProvider
   systemPrompt: string
-  llmConfig: ICustomAgentModelProviderLlmConfig = DEFAULT_CONFIG
+  llmConfig: ICustomAgentModelProviderLlmConfig = { ...DEFAULT_SHARED_CONFIG, ...DEFAULT_FACTORY_CONFIG }
 
   constructor(
     config: AIModelConfig,
@@ -35,21 +37,33 @@ export class CustomAgentModelProvider extends BaseModelProvider {
   ) {
     super(config)
 
-    const mergedConfig: ICustomAgentModelProviderLlmConfig = {
-      ...DEFAULT_CONFIG,
-      ...(llmConfig || {})
+    let mergedConfig: ICustomAgentModelProviderLlmConfig
+    if (llmConfig && 'llm' in llmConfig) {
+      mergedConfig = {
+        ...DEFAULT_SHARED_CONFIG,
+        ...llmConfig
+      }
+    } else {
+      mergedConfig = {
+        ...DEFAULT_SHARED_CONFIG,
+        ...DEFAULT_FACTORY_CONFIG,
+        ...(llmConfig || {})
+      }
     }
 
     this.llmConfig = mergedConfig
 
+    const llmConfigOption = mergedConfig.llm
+      ? { llm: mergedConfig.llm }
+      : {
+          apiKey: mergedConfig.apiKey!,
+          baseURL: mergedConfig.baseURL!,
+          providerType: mergedConfig.providerType!
+        }
+
     const options: IAgentModelProviderOption = {
       mcpServers: this.createMcpServers(sessionId.value, agentRoot.value),
-      llmConfig: {
-        apiKey: mergedConfig.apiKey,
-        baseURL: mergedConfig.baseURL,
-        providerType: mergedConfig.providerType,
-        llm: mergedConfig.llm
-      }
+      llmConfig: llmConfigOption
     }
 
     this.agent = new AgentModelProvider(options)

--- a/packages/next-remoter/src/composable/useNextAgent.ts
+++ b/packages/next-remoter/src/composable/useNextAgent.ts
@@ -18,7 +18,8 @@ export type INextAgetOption = {
    * 如果设置，则代替内部默认的流处理函数。
    */
   processStream?: (stream: ReadableStream<string>, messages: Ref<any[]>, senderContent: string) => Promise<void>
-} & Partial<Pick<IAgentModelProviderOption, 'llm' | 'llmConfig'>>
+  llmConfig: IAgentModelProviderOption['llmConfig']
+}
 
 /** 快速实现Opentiny Next遥控器的智能体
  *
@@ -30,7 +31,6 @@ export type INextAgetOption = {
 export function useNextAgent(option: INextAgetOption) {
   const initMcpServers: any = option.sessionId ? createMcpServers(option.sessionId, option.agentRoot) : []
   const agent = new AgentModelProvider({
-    llm: option.llm,
     llmConfig: option.llmConfig,
     mcpServers: initMcpServers
   })

--- a/packages/next-remoter/src/composable/useTinyRobotChat.ts
+++ b/packages/next-remoter/src/composable/useTinyRobotChat.ts
@@ -12,21 +12,19 @@ interface useTinyRobotOption {
   agentRoot: Ref<string>
   systemPrompt: string
   llmConfig?: ICustomAgentModelProviderLlmConfig
-  llm?: any
 }
 
 let accmulateText = ''
 let summaryText = ''
 let accmulateMessagesLength: number = 0
 
-export const useTinyRobotChat = ({ sessionId, agentRoot, systemPrompt, llmConfig, llm }: useTinyRobotOption) => {
+export const useTinyRobotChat = ({ sessionId, agentRoot, systemPrompt, llmConfig }: useTinyRobotOption) => {
   const customAgentProvider = new CustomAgentModelProvider(
     { provider: 'custom' },
     sessionId,
     agentRoot,
     systemPrompt,
-    llmConfig,
-    llm
+    llmConfig
   )
   const client = new AIClient({
     providerImplementation: customAgentProvider,

--- a/packages/next-remoter/src/types/type.ts
+++ b/packages/next-remoter/src/types/type.ts
@@ -12,7 +12,7 @@ export interface StreamPart {
 
 export interface ICustomAgentModelProviderLlmConfig extends IAgentModelProviderLlmConfig {
   model: string
-  maxSteps: number
-  providerOptions: any
-  extraTools: any
+  maxSteps?: number
+  providerOptions?: Record<string, any>
+  extraTools?: Record<string, any>
 }

--- a/packages/next-remoter/src/types/type.ts
+++ b/packages/next-remoter/src/types/type.ts
@@ -10,7 +10,7 @@ export interface StreamPart {
   toolCallId?: string
 }
 
-export interface ICustomAgentModelProviderLlmConfig extends IAgentModelProviderLlmConfig {
+export type ICustomAgentModelProviderLlmConfig = IAgentModelProviderLlmConfig & {
   model: string
   maxSteps?: number
   providerOptions?: Record<string, any>

--- a/packages/next-sdk/agent/AgentModelProvider.ts
+++ b/packages/next-sdk/agent/AgentModelProvider.ts
@@ -55,12 +55,13 @@ export class AgentModelProvider {
     if (llmConfig.llm) {
       this.llm = llmConfig.llm
     } else if (llmConfig.providerType) {
+      const providerType = llmConfig.providerType
       let providerFn: (options: any) => ProviderV2 | OpenAIProvider
 
-      if (typeof llmConfig.providerType === 'string') {
-        providerFn = AIProviderFactories[llmConfig.providerType]
+      if (typeof providerType === 'string') {
+        providerFn = AIProviderFactories[providerType]
       } else {
-        providerFn = llmConfig.providerType
+        providerFn = providerType
       }
       this.llm = providerFn({
         apiKey: llmConfig.apiKey,

--- a/packages/next-sdk/agent/AgentModelProvider.ts
+++ b/packages/next-sdk/agent/AgentModelProvider.ts
@@ -44,14 +44,17 @@ export class AgentModelProvider {
   /** 缓存 ai-sdk response 中的 多轮会话的上下文 */
   messages: any[] = []
 
-  constructor({ llmConfig, mcpServers, llm }: IAgentModelProviderOption) {
+  constructor({ llmConfig, mcpServers }: IAgentModelProviderOption) {
+    if (!llmConfig) {
+      throw new Error('llmConfig is required to initialize AgentModelProvider')
+    }
     this.mcpServers = mcpServers || {}
     this.mcpClients = {}
     this.mcpTools = {}
 
-    if (llm) {
-      this.llm = llm
-    } else if (llmConfig) {
+    if (llmConfig.llm) {
+      this.llm = llmConfig.llm
+    } else if (llmConfig.providerType) {
       let providerFn: (options: any) => ProviderV2 | OpenAIProvider
 
       if (typeof llmConfig.providerType === 'string') {
@@ -64,7 +67,7 @@ export class AgentModelProvider {
         baseURL: llmConfig.baseURL
       })
     } else {
-      throw new Error('Either llmConfig or llm must be provided')
+      throw new Error('Either llmConfig.llm or llmConfig.providerType must be provided')
     }
   }
 

--- a/packages/next-sdk/agent/type.ts
+++ b/packages/next-sdk/agent/type.ts
@@ -2,18 +2,30 @@ export type { experimental_MCPClient as MCPClient } from 'ai'
 import type { ProviderV2 } from '@ai-sdk/provider'
 import type { MCPTransport } from 'ai'
 
-/** 代理模型提供器的大语言配置对象 */
-export interface IAgentModelProviderLlmConfig {
-  apiKey?: string
-  baseURL?: string
-  /** 支持内置的常用模型，或者传入一个ai-sdk官方的Provider工厂函数
-   * @example
-   * import { createOpenAI } from '@ai-sdk/openai'
-   */
-  providerType?: 'openai' | 'deepseek' | ((options: any) => ProviderV2)
-  /** 自定义 Provider 实例，优先级最高 */
-  llm?: ProviderV2
+type ProviderFactory = 'openai' | 'deepseek' | ((options: any) => ProviderV2)
+
+type LlmFactoryConfig = {
+  /** API密钥 */
+  apiKey: string
+  /** API基础URL */
+  baseURL: string
+  /** 内置或自定义 Provider 工厂函数 */
+  providerType: ProviderFactory
+  /** 互斥：当使用 providerType 分支时不允许传入 llm */
+  llm?: never
 }
+
+type LlmInstanceConfig = {
+  /** 自定义 Provider 实例，优先级最高 */
+  llm: ProviderV2
+  /** 互斥：当传入 llm 实例时不需要 apiKey/baseURL/providerType */
+  apiKey?: never
+  baseURL?: never
+  providerType?: never
+}
+
+/** 代理模型提供器的大语言配置对象, 通过 XOR 表达二选一 */
+export type IAgentModelProviderLlmConfig = LlmFactoryConfig | LlmInstanceConfig
 
 /** Mcp Server的配置对象 */
 export type McpServerConfig =

--- a/packages/next-sdk/agent/type.ts
+++ b/packages/next-sdk/agent/type.ts
@@ -4,13 +4,15 @@ import type { MCPTransport } from 'ai'
 
 /** 代理模型提供器的大语言配置对象 */
 export interface IAgentModelProviderLlmConfig {
-  apiKey: string
-  baseURL: string
+  apiKey?: string
+  baseURL?: string
   /** 支持内置的常用模型，或者传入一个ai-sdk官方的Provider工厂函数
    * @example
    * import { createOpenAI } from '@ai-sdk/openai'
    */
-  providerType: 'openai' | 'deepseek' | ((options: any) => ProviderV2)
+  providerType?: 'openai' | 'deepseek' | ((options: any) => ProviderV2)
+  /** 自定义 Provider 实例，优先级最高 */
+  llm?: ProviderV2
 }
 
 /** Mcp Server的配置对象 */
@@ -22,13 +24,8 @@ export type McpServerConfig =
 
 /** */
 export interface IAgentModelProviderOption {
-  /** ai-sdk官方的Provider实例，不能与 llmConfig 同时传入
-   * @example
-   * import { openai } from '@ai-sdk/openai'
-   */
-  llm?: ProviderV2
-  /** 代理模型提供器的大语言配置对象, 不能与 llm 同时传入 */
-  llmConfig?: IAgentModelProviderLlmConfig
+  /** 代理模型提供器的大语言配置对象 */
+  llmConfig: IAgentModelProviderLlmConfig
   /** Mcp Server的配置对象的集合，键为服务器名称，值为配置对象 */
   mcpServers?: Record<string, McpServerConfig>
 }

--- a/packages/next-wxt/components.d.ts
+++ b/packages/next-wxt/components.d.ts
@@ -9,5 +9,6 @@ declare module 'vue' {
   export interface GlobalComponents {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
+    VanIcon: typeof import('vant/es')['Icon']
   }
 }


### PR DESCRIPTION
feat: 统一llmConfig配置，解决remoter传入llm配置项无法传入model配置问题，修改对应的文档

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Consolidated LLM configuration into a single required `llmConfig` parameter; separate `llm` property removed from components and APIs.
  * `llmConfig` now supports both direct provider instances and factory-based configuration methods.

* **Documentation**
  * Updated guides and examples to reflect unified configuration approach.

* **Chores**
  * Version bumped to 0.0.7.
  * Updated component registration typings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->