### PR TITLE
fix: remove tabId from ExtensionPageServerTransport and related logic

### DIFF
--- a/packages/doc-ai/src/AppExtension.vue
+++ b/packages/doc-ai/src/AppExtension.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="app-container"></div>
+</template>
+
+<script setup lang="ts">
+import { WebMcpServer, ExtensionPageServerTransport, z } from '@opentiny/next-sdk'
+import { onMounted } from 'vue'
+
+const serverInfo = {
+  name: 'demo-server',
+  version: '1.0.0'
+}
+// Create an MCP server
+const server = new WebMcpServer(serverInfo)
+
+server.registerTool(
+  'generate-color-extension',
+  {
+    title: '生成页面背景颜色',
+    description: '根据用户的心情或者情绪生成页面的背景颜色,要求：传入的color参数格式为十六进制颜色值,比如 #000000',
+    inputSchema: { color: z.string() }
+  },
+  async ({ color }) => {
+    document.body.style.backgroundColor = color
+    return {
+      content: [{ type: 'text', text: String(color) }]
+    }
+  }
+)
+
+const sessionId = localStorage.getItem('mcp-sessionId-extension')
+
+// Create pair MCP transports
+
+onMounted(() => {
+  setTimeout(async () => {
+    const serverTransport = new ExtensionPageServerTransport(sessionId)
+    localStorage.setItem('mcp-sessionId', serverTransport.sessionId)
+
+    console.log(serverTransport.sessionId)
+    // Connect the client and server
+    await server.connect(serverTransport)
+    serverTransport.notifyRegistration(serverInfo)
+  }, 1000)
+})
+</script>
+
+<style scoped></style>

--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-remoter",
-  "version": "0.0.10",
+  "version": "0.0.10-beta.1",
   "type": "module",
   "files": [
     "dist"

--- a/packages/next-sdk/agent/type.ts
+++ b/packages/next-sdk/agent/type.ts
@@ -1,6 +1,8 @@
-export type { experimental_MCPClient as MCPClient } from 'ai'
 import type { ProviderV2 } from '@ai-sdk/provider'
-import type { MCPTransport } from 'ai'
+import type { experimental_MCPClientConfig as MCPClientConfig } from '@ai-sdk/mcp'
+
+// 从 MCPClientConfig 中提取 transport 类型
+export type MCPTransport = MCPClientConfig['transport']
 
 type ProviderFactory = 'openai' | 'deepseek' | ((options: any) => ProviderV2)
 

--- a/packages/next-sdk/package.json
+++ b/packages/next-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-sdk",
-  "version": "0.1.15",
+  "version": "0.1.15-beta.1",
   "type": "module",
   "license": "MIT",
   "author": "Chunhui Mo",

--- a/packages/next-sdk/transport/ExtensionPageServerTransport.ts
+++ b/packages/next-sdk/transport/ExtensionPageServerTransport.ts
@@ -28,7 +28,6 @@ export class ExtensionPageServerTransport implements Transport {
 
   // 会话ID，用于标识此 transport 实例并路由消息
   readonly sessionId: string
-  readonly tabId: number
 
   // 内部状态
   private _messageListener1: () => void
@@ -47,10 +46,9 @@ export class ExtensionPageServerTransport implements Transport {
     }
   }
 
-  constructor(sessionId: string | null = null, tabId: number) {
+  constructor(sessionId: string | null = null) {
     // 如果提供了 sessionId，使用提供的；否则随机生成
     this.sessionId = sessionId || randomUUID()
-    this.tabId = tabId
 
     this._messageListener1 = onWindowMessage(
       'sidepanel-ready-to-page',
@@ -67,7 +65,7 @@ export class ExtensionPageServerTransport implements Transport {
     this._messageListener2 = onWindowMessage(
       'mcp-client-to-server-to-page',
       (data) => {
-        if (data.sessionId !== this.sessionId || data.tabId !== this.tabId) return
+        if (data.sessionId !== this.sessionId) return
 
         console.log('【Page Svr Transport】 即将处理 mcpMessage', data.mcpMessage)
         const mcpMessage = JSONRPCMessageSchema.parse(data.mcpMessage)

--- a/packages/next-wxt/components.d.ts
+++ b/packages/next-wxt/components.d.ts
@@ -9,6 +9,5 @@ declare module 'vue' {
   export interface GlobalComponents {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
-    VanIcon: typeof import('vant/es')['Icon']
   }
 }

--- a/packages/next-wxt/entrypoints/content.ts
+++ b/packages/next-wxt/entrypoints/content.ts
@@ -77,6 +77,9 @@ export default defineContentScript({
             console.warn('【Content Script】未知的 MCP 服务器类型:', mcpMeta.type)
           }
         }
+      } else {
+        // 当用户在自己的应用中集成需要创建代理
+        createContentProxy(tabId)
       }
       mountPageApp()
     }

--- a/packages/next-wxt/public/vendor/mcp-server.js
+++ b/packages/next-wxt/public/vendor/mcp-server.js
@@ -17,36 +17,10 @@ function getCookieData() {
   }, {})
 }
 
-// 成功返回tabId, 失败返回-1
-function getTabId() {
-  return new Promise((resolve, reject) => {
-    // 先监听，后发送信息。 超时1秒算失败
-    function handler(event) {
-      if (event.source === window && event.data.type === 'answer-tabid') {
-        window.removeEventListener('message', handler)
-        resolve(event.data.data.tabId)
-      }
-    }
-    window.addEventListener('message', handler)
-
-    window.postMessage({ type: 'ask-tabid', direction: 'page->content', data: {} }, '*')
-    setTimeout(() => {
-      reject(-1)
-    }, 10000)
-  })
-}
-
 async function connect() {
   console.log('MAIN world 脚本已加载，等待 content proxy 就绪...')
 
   await waitForContentProxy()
-  const tabId = await getTabId()
-  if (tabId === -1) {
-    console.log('Main 页面无法查询自己的tabId')
-    return
-  } else {
-    console.log('Main 页面自己的tabId=', tabId)
-  }
 
   const serverInfo = {
     name: 'demo-server',
@@ -60,7 +34,7 @@ async function connect() {
     const sessionId = localStorage.getItem('mcp-sessionId')
 
     // Create pair MCP transports
-    const serverTransport = new ExtensionPageServerTransport(sessionId, tabId)
+    const serverTransport = new ExtensionPageServerTransport(sessionId)
     localStorage.setItem('mcp-sessionId', serverTransport.sessionId)
 
     console.log(serverTransport.sessionId)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ catalog:
   '@matechat/core': ^1.9.0
   # mcp
   '@modelcontextprotocol/inspector': ^0.16.1
-  '@modelcontextprotocol/sdk': ^1.16.0
+  '@modelcontextprotocol/sdk': ~1.24.3
 
   # 生成ui
   '@opentiny/genui-sdk': 0.0.1-alpha.0


### PR DESCRIPTION
fix: 修复用户项目需要传递tabId的问题，因为用户页面获取不到tabId

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a color-generation extension tool with configurable hex input.
  * Added fallback content-proxy creation when no MCP configuration is present.

* **Improvements**
  * Simplified routing to rely on sessionId only, removing tabId-dependent behavior and related logging.
  * Cleaned up public type and global component declarations to match current API surface.

* **Chores**
  * Bumped select package versions and marked SDK packages as beta.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->