### PR TITLE
fix: fixed the problem of failure to call extensionTransport connection tool in ReAct mode

### DIFF
--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-remoter",
-  "version": "0.0.10-beta.1",
+  "version": "0.0.10-beta.2",
   "type": "module",
   "files": [
     "dist"

--- a/packages/next-sdk/agent/AgentModelProvider.ts
+++ b/packages/next-sdk/agent/AgentModelProvider.ts
@@ -141,7 +141,6 @@ export class AgentModelProvider {
       }
 
       // 因为它们是基于 Chrome 扩展的消息传递机制，关闭会影响服务端的连接
-      // 而且这些 transport 的生命周期应该由外部管理，不应该在 client 关闭时被关闭
       if (transport && transport instanceof ExtensionClientTransport) {
         return
       }

--- a/packages/next-sdk/agent/AgentModelProvider.ts
+++ b/packages/next-sdk/agent/AgentModelProvider.ts
@@ -131,11 +131,18 @@ export class AgentModelProvider {
     try {
       const transport = client['__transport__']
 
-      // 如果是 InMemoryTransport，不关闭传输层 因为它是配对的，关闭一端会影响另一端（服务端）
+      // 如果是 InMemoryTransport 或 MessageChannelTransport，不关闭传输层
+      // 因为它们是配对的，关闭一端会影响另一端（服务端）
       if (
         (transport && transport instanceof InMemoryTransport) ||
         (transport && transport instanceof MessageChannelTransport)
       ) {
+        return
+      }
+
+      // 因为它们是基于 Chrome 扩展的消息传递机制，关闭会影响服务端的连接
+      // 而且这些 transport 的生命周期应该由外部管理，不应该在 client 关闭时被关闭
+      if (transport && transport instanceof ExtensionClientTransport) {
         return
       }
 

--- a/packages/next-sdk/package.json
+++ b/packages/next-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-sdk",
-  "version": "0.1.15-beta.1",
+  "version": "0.1.15-beta.2",
   "type": "module",
   "license": "MIT",
   "author": "Chunhui Mo",


### PR DESCRIPTION
fix: 修复ReAct模式下调用extensionTransport连接的工具失败问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transport connection handling to prevent server connection interruptions by refining which connection types are terminated during cleanup operations.

* **Chores**
  * Version updates: next-remoter (0.0.10-beta.1 → 0.0.10-beta.2) and next-sdk (0.1.15-beta.1 → 0.1.15-beta.2).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->