### PR TITLE
fix(remoter): fix issue#286 

### DIFF
--- a/docs/guide/api-createRemoter.md
+++ b/docs/guide/api-createRemoter.md
@@ -36,6 +36,7 @@ const remoter = createRemoter({
 | ------------ | ---------------- | ---- | ------------------------------------------ | ---------------------- |
 | sessionId    | string           | ✅   | -                                          | 被遥控页面的会话ID     |
 | qrCodeUrl    | string           | ❌   | https:\/\/ai.opentiny.design\/next-remoter | 遥控端页面地址         |
+| logoUrl      | string           | ❌   | -                                          | 悬浮AI LogUrl地址      |
 | onShowAIChat | function         | ❌   | -                                          | 显示AI对话框的回调函数 |
 | menuItems    | MenuItemConfig[] | ❌   | 默认配置                                   | 菜单项配置数组         |
 

--- a/docs/guide/tiny-robot-remoter.md
+++ b/docs/guide/tiny-robot-remoter.md
@@ -33,6 +33,7 @@ import { TinyRemoter } from '@opentiny/next-remoter'
 - `mode` 展示模式，可选值为：'remoter' | 'chat-dialog'。遥控器模式： 自动在右下角显示一个AI图标，点击展开多个菜单项； 对话框模式： 直接显示一个对话框界面
 - `remoteUrl` 远程URL，用于显示在遥控器模式下，点击遥控器图标后，显示的菜单项。
 - `qrCodeUrl` 二维码URL，用于显示在遥控器模式下，点击遥控器图标后，弹出二维码对应的链接 url。
+- `AILogoUrl` AI图标的 url 地址。
 - `menuItems` 菜单项配置数组，用于显示在遥控器模式下，点击遥控器图标后，显示的菜单项。具体配置项见 [api-createRemoter](./api-createRemoter.md)
 - `systemPrompt` 对话llm 时，传入的 system message: system-prompt=你是一个智能助手，工作地点是深圳
 - `llmConfig` 大语言模型配置对象，支持配置 `apiKey`、`baseURL` 、 `model` 、`maxSteps` 、 `providerType` 、 `providerOptions`、`extraTools`，其中 `apiKey/baseURL/providerType` 与 `llmConfig.llm` 二选一
@@ -325,12 +326,12 @@ const show = ref(false)
 <template>
   <div class="chat-container">
     <!-- 静态定位，组件会占据 100% 的宽高，适合嵌入页面 -->
-    <TinyRemoter 
-      v-model:show="show" 
+    <TinyRemoter
+      v-model:show="show"
       layout-mode="static"
-      sessionId="your-session-id" 
-      title="我的AI助手" 
-      systemPrompt="你是一个智能助手" 
+      sessionId="your-session-id"
+      title="我的AI助手"
+      systemPrompt="你是一个智能助手"
     />
   </div>
 </template>
@@ -366,12 +367,12 @@ const show = ref(true)
     </div>
 
     <!-- 动态布局模式 -->
-    <TinyRemoter 
-      v-model:show="show" 
+    <TinyRemoter
+      v-model:show="show"
       :layout-mode="layoutMode"
-      sessionId="your-session-id" 
-      title="我的AI助手" 
-      systemPrompt="你是一个智能助手" 
+      sessionId="your-session-id"
+      title="我的AI助手"
+      systemPrompt="你是一个智能助手"
     />
   </div>
 </template>

--- a/docs/guide/tiny-robot-remoter.md
+++ b/docs/guide/tiny-robot-remoter.md
@@ -34,7 +34,7 @@ import { TinyRemoter } from '@opentiny/next-remoter'
 - `remoteUrl` 远程URL，用于显示在遥控器模式下，点击遥控器图标后，显示的菜单项。
 - `qrCodeUrl` 二维码URL，用于显示在遥控器模式下，点击遥控器图标后，弹出二维码对应的链接 url。
 - `AILogoUrl` AI图标的 url 地址。
-- `menuItems` 菜单项配置数组，用于显示在遥控器模式下，点击遥控器图标后，显示的菜单项。具体配置项见 [api-createRemoter](./api-createRemoter.md)
+- `menuItems` 菜单项配置数组，用于显示在遥控器模式下，点击遥控器图标后，显示的菜单项。具体配置项见 [api-createRemoter](./api-createRemoter.md)。 它默认情况下显示全部菜单，若传入空数组，则不显示菜单。
 - `systemPrompt` 对话llm 时，传入的 system message: system-prompt=你是一个智能助手，工作地点是深圳
 - `llmConfig` 大语言模型配置对象，支持配置 `apiKey`、`baseURL` 、 `model` 、`maxSteps` 、 `providerType` 、 `providerOptions`、`extraTools`，其中 `apiKey/baseURL/providerType` 与 `llmConfig.llm` 二选一
 - `llmConfigs` LLM 配置数组（`UnifiedModelConfig[]` 类型），每一项基于 `llmConfig` 格式，额外包含 `id`、`label`、`icon`、`isDefault`、`useReActMode` 字段。传入此属性后，会在头部显示模型切换组件，支持通过 `v-model:selectedModelId` 控制选中的模型

--- a/packages/next-remoter/components.d.ts
+++ b/packages/next-remoter/components.d.ts
@@ -16,6 +16,5 @@ declare module 'vue' {
     RouterView: typeof import('vue-router')['RouterView']
     TinyRobotChat: typeof import('./src/components/TinyRobotChat.vue')['default']
     TokenUsage: typeof import('./src/components/tokenUsage.vue')['default']
-    VanIcon: typeof import('vant/es')['Icon']
   }
 }

--- a/packages/next-remoter/components.d.ts
+++ b/packages/next-remoter/components.d.ts
@@ -16,5 +16,6 @@ declare module 'vue' {
     RouterView: typeof import('vue-router')['RouterView']
     TinyRobotChat: typeof import('./src/components/TinyRobotChat.vue')['default']
     TokenUsage: typeof import('./src/components/tokenUsage.vue')['default']
+    VanIcon: typeof import('vant/es')['Icon']
   }
 }

--- a/packages/next-remoter/src/components/TinyRobotChat.vue
+++ b/packages/next-remoter/src/components/TinyRobotChat.vue
@@ -205,8 +205,7 @@ const props = defineProps({
     type: String
   },
   menuItems: {
-    type: Array as () => MenuItemConfig[],
-    default: () => []
+    type: Array as () => MenuItemConfig[]
   },
   qrCodeUrl: {
     type: String

--- a/packages/next-remoter/src/components/TinyRobotChat.vue
+++ b/packages/next-remoter/src/components/TinyRobotChat.vue
@@ -156,7 +156,7 @@ import { IconNewSession, IconHistory } from '@opentiny/tiny-robot-svgs'
 import { useTinyRobotChat } from '../composable/useTinyRobotChat'
 import { useCustomMcpServer } from '../composable/useCustomMcpServer'
 import { usePlugin } from '../composable/usePlugin'
-import { toRef, computed, ref, onMounted, h, watch, type Ref } from 'vue'
+import { toRef, computed, ref, onMounted, h, watch, type Ref, type ComponentInstance } from 'vue'
 import { createRemoter } from '@opentiny/next-sdk'
 import QrCodeScan from './QrCodeScan.vue'
 import ModelSwitch from './ModelSwitch.vue'
@@ -511,7 +511,7 @@ defineExpose({
   /** 输入框的文本 */
   inputMessage,
   /** 输入框组件的实例 */
-  senderRef,
+  senderRef: senderRef as Ref<ComponentInstance<typeof TrSender>>,
   /** 取消发送 */
   abortRequest,
   /** 发送消息 */

--- a/packages/next-remoter/src/components/TinyRobotChat.vue
+++ b/packages/next-remoter/src/components/TinyRobotChat.vue
@@ -211,6 +211,10 @@ const props = defineProps({
   qrCodeUrl: {
     type: String
   },
+  /** 悬浮AI图标的地址 */
+  AILogoUrl: {
+    type: String
+  },
   /** 展示模式： 'remoter' | 'chat-dialog'
    * 遥控器模式： 自动在右下角显示一个AI图标，点击展开多个菜单项。
    * 对话框模式： 直接显示一个对话框界面
@@ -434,6 +438,7 @@ watch(
         qrCodeUrl: props.qrCodeUrl,
         remoteUrl: props.remoteUrl,
         menuItems: props.menuItems,
+        logoUrl: props.AILogoUrl,
         onShowAIChat: () => (show.value = true)
       })
 

--- a/packages/next-sdk/remoter/createRemoter.ts
+++ b/packages/next-sdk/remoter/createRemoter.ts
@@ -93,6 +93,8 @@ class FloatingBlock {
   private floatingBlock!: HTMLDivElement
   private dropdownMenu!: HTMLDivElement
   private menuItems: MenuItemConfig[]
+  /** 即将关闭dropdown的定时器 */
+  private closingTimer = 0
 
   // 计算 sessionPrefix 属性
   private get sessionPrefix(): string {
@@ -240,11 +242,30 @@ class FloatingBlock {
   private bindEvents(): void {
     // 绑定浮动块点击事件
     this.floatingBlock.addEventListener('click', () => {
-      if (this.menuItems.length > 0) {
-        this.toggleDropdown()
-      } else {
-        this.showAIChat()
+      this.showAIChat()
+    })
+
+    // 浮动块悬浮处理
+    this.floatingBlock.addEventListener('mouseenter', () => {
+      this.openDropdown()
+
+      if (this.closingTimer) {
+        window.clearTimeout(this.closingTimer)
+        this.closingTimer = 0
       }
+    })
+    this.floatingBlock.addEventListener('mouseleave', () => {
+      this.shouldCloseDropdown()
+    })
+    // 悬浮菜单进入，则阻止关闭
+    this.dropdownMenu.addEventListener('mouseenter', (e: Event) => {
+      if (this.closingTimer) {
+        window.clearTimeout(this.closingTimer)
+        this.closingTimer = 0
+      }
+    })
+    this.dropdownMenu.addEventListener('mouseleave', (e: Event) => {
+      this.shouldCloseDropdown()
     })
 
     // 绑定菜单项点击事件
@@ -286,20 +307,24 @@ class FloatingBlock {
     })
   }
 
-  private toggleDropdown(): void {
-    if (this.isExpanded) {
-      this.closeDropdown()
-    } else {
-      this.openDropdown()
-    }
-  }
-
   private openDropdown(): void {
+    // 没有menuItems，则返回
+    if (!this.menuItems || (this.menuItems && this.menuItems.length === 0)) {
+      return
+    }
+
     this.isExpanded = true
     this.floatingBlock.classList.add('expanded')
     this.dropdownMenu.classList.add('show')
   }
 
+  private shouldCloseDropdown() {
+    this.closingTimer = window.setTimeout(() => {
+      this.closeDropdown()
+    }, 300)
+  }
+
+  /** 真正的立即关闭 */
   private closeDropdown(): void {
     this.isExpanded = false
     this.floatingBlock.classList.remove('expanded')

--- a/packages/next-sdk/remoter/createRemoter.ts
+++ b/packages/next-sdk/remoter/createRemoter.ts
@@ -8,6 +8,7 @@ import iconCopy from './svgs/icon-copy.svg?url'
 
 const DEFAULT_REMOTE_URL = 'https://agent.opentiny.design/tiny-robot'
 const DEFAULT_QR_CODE_URL = 'https://ai.opentiny.design/next-remoter'
+const DEFAULT_LOGO_URL = 'https://ai.opentiny.design/next-remoter/svgs/logo-next-no-bg-left.svg'
 
 /** 菜单项配置接口 */
 export interface MenuItemConfig {
@@ -44,6 +45,8 @@ export interface FloatingBlockOptions {
   menuItems?: MenuItemConfig[]
   /** 遥控端页面地址，默认为： https://agent.opentiny.design/tiny-robot */
   remoteUrl?: string
+  /** 悬浮Logo的url地址，默认为： https://ai.opentiny.design/next-remoter/svgs/logo-next-no-bg-left.svg */
+  logoUrl?: string
 }
 
 // 动作类型
@@ -109,7 +112,8 @@ class FloatingBlock {
     this.options = {
       ...options,
       qrCodeUrl: options.qrCodeUrl || DEFAULT_QR_CODE_URL,
-      remoteUrl: options.remoteUrl || DEFAULT_REMOTE_URL
+      remoteUrl: options.remoteUrl || DEFAULT_REMOTE_URL,
+      logoUrl: options.logoUrl || DEFAULT_LOGO_URL
     }
 
     // 合并默认菜单项配置和用户配置。  用户不传入任何menu时， 则不自动合并默认菜单了，即不渲染任何菜单。
@@ -178,7 +182,7 @@ class FloatingBlock {
     this.floatingBlock.className = 'tiny-remoter-floating-block'
     this.floatingBlock.innerHTML = `
       <div class="tiny-remoter-floating-block__icon">
-        <img style="display: block; width: 56px;" src="${DEFAULT_QR_CODE_URL}/svgs/logo-next-no-bg-left.svg" alt="icon" />
+        <img style="display: block; width: 56px;" src="${this.options.logoUrl}" alt="icon" />
       </div>
     `
 

--- a/packages/next-sdk/remoter/createRemoter.ts
+++ b/packages/next-sdk/remoter/createRemoter.ts
@@ -1,10 +1,10 @@
 import { QrCode } from './QrCode'
-import { Tooltip } from './tooltips';
-import chat from './svgs/chat.svg?url'; 
-import scan from './svgs/scan.svg?url'; 
-import link from './svgs/link.svg?url'; 
-import qrCode from './svgs/qrcode.svg?url'; 
-import iconCopy from './svgs/icon-copy.svg?url'; 
+import { Tooltip } from './tooltips'
+import chat from './svgs/chat.svg?url'
+import scan from './svgs/scan.svg?url'
+import link from './svgs/link.svg?url'
+import qrCode from './svgs/qrcode.svg?url'
+import iconCopy from './svgs/icon-copy.svg?url'
 
 const DEFAULT_REMOTE_URL = 'https://agent.opentiny.design/tiny-robot'
 const DEFAULT_QR_CODE_URL = 'https://ai.opentiny.design/next-remoter'
@@ -20,7 +20,7 @@ export interface MenuItemConfig {
   /** 菜单文字颜色 */
   active?: boolean
   /** 识别码 */
-  know?: boolean  
+  know?: boolean
   /** 菜单项描述 */
   desc?: string
   /** 菜单项提示 */
@@ -83,7 +83,7 @@ const getDefaultMenuItems = (options: FloatingBlockOptions): MenuItemConfig[] =>
       know: true,
       showCopyIcon: true,
       icon: scan
-    },
+    }
   ]
 }
 
@@ -110,31 +110,33 @@ class FloatingBlock {
       remoteUrl: options.remoteUrl || DEFAULT_REMOTE_URL
     }
 
-    // 合并默认菜单项配置和用户配置
-    this.menuItems = this.mergeMenuItems(options.menuItems)
+    // 合并默认菜单项配置和用户配置。  用户不传入任何menu时， 则不自动合并默认菜单了，即不渲染任何菜单。
+    if (options.menuItems && options.menuItems.length === 0) {
+      this.menuItems = []
+    } else {
+      this.menuItems = this.mergeMenuItems(options.menuItems)
+    }
 
     this.init()
   }
 
   private getImageUrl = (asset: string | undefined): HTMLImageElement | undefined => {
-    if (!asset) return;
-    const img = new Image();
-    img.src = asset;
-    return img;
+    if (!asset) return
+    const img = new Image()
+    img.src = asset
+    return img
   }
 
   private renderItem = (): void => {
     this.menuItems
       .filter((item) => item.show !== false) // 过滤掉show为false的菜单项
-      .map(
-        (item) => {
-          const wrapper = document.getElementById(`tiny-remoter-icon-item-${item.action}`) as HTMLDivElement;
-          if (!wrapper) return;
-          wrapper.innerHTML = '';
-          const img = this.getImageUrl(item.icon);
-          if (img) wrapper.appendChild(img);
-      }
-    );
+      .map((item) => {
+        const wrapper = document.getElementById(`tiny-remoter-icon-item-${item.action}`) as HTMLDivElement
+        if (!wrapper) return
+        wrapper.innerHTML = ''
+        const img = this.getImageUrl(item.icon)
+        if (img) wrapper.appendChild(img)
+      })
   }
 
   /**
@@ -211,13 +213,14 @@ class FloatingBlock {
             <div class="tiny-remoter-dropdown-item__desc-wrapper">
               <div class="tiny-remoter-dropdown-item__desc ${item.active ? 'tiny-remoter-dropdown-item__desc--active' : ''} ${item.know ? 'tiny-remoter-dropdown-item__desc--know' : ''}">${item.desc}</div>
               <div>
-                ${item.showCopyIcon
-                     ? `
+                ${
+                  item.showCopyIcon
+                    ? `
                    <div class="tiny-remoter-copy-icon" id="${item.action}" data-action="${item.action}">
                       <img src="${iconCopy}"/>
                    </div>
                  `
-                     : ''
+                    : ''
                 }
               </div>
             </div>
@@ -234,11 +237,14 @@ class FloatingBlock {
     this.readyTips(`remote-url`)
   }
 
-
   private bindEvents(): void {
     // 绑定浮动块点击事件
     this.floatingBlock.addEventListener('click', () => {
-      this.toggleDropdown()
+      if (this.menuItems.length > 0) {
+        this.toggleDropdown()
+      } else {
+        this.showAIChat()
+      }
     })
 
     // 绑定菜单项点击事件


### PR DESCRIPTION
修复 ISSUE#286提出的优化建议，详情见issue

fix(remoter): 如果用户不传入menuItem, 则不显示悬浮列表。
fix(remotor): 修改AI图标触发菜单显示为hover， 并修改图标点击事件为展开对话框
fix(remoter): 为createRemoter 增加自定义AIlogo的功能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Add custom AI logo URLs to remoter components with default fallback option
  * Improved dropdown interactions with enhanced hover-based controls
  * Hide menu items by passing an empty array to menuItems configuration

* **Documentation**
  * Updated API and component documentation for new logo and menu configuration options

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->