### PR TITLE
fix(promise): 防止chat函数立即返回，就不能够取消对话

### DIFF
--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -58,7 +58,8 @@
     "@vueuse/core": "^14.1.0",
     "@ai-sdk/deepseek": "catalog:",
     "@ai-sdk/openai": "catalog:",
-    "@ai-sdk/provider": "catalog:"
+    "@ai-sdk/provider": "catalog:",
+    "@ai-sdk/provider-utils": "catalog:"
   },
   "devDependencies": {
     "@opentiny/unplugin-tiny-vue": "catalog:",

--- a/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
+++ b/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
@@ -14,6 +14,7 @@ import type { OpenAIProvider } from '@ai-sdk/openai'
 import { GENUI_CONFIG } from '../config/genui-config'
 import { StreamVisitor } from './streamVisitor'
 import { extractTextAndJson } from './handleSchema'
+import { DelayedPromise } from '@ai-sdk/provider-utils'
 
 const DEFAULT_SHARED_CONFIG = {
   model: 'deepseek-ai/DeepSeek-V3',
@@ -386,9 +387,12 @@ export class CustomAgentModelProvider extends BaseModelProvider {
 
     const result = await this.agent.chatStream(chatStreamOptions)
 
+    // 待返回的promise对象，用户阻塞住函数立即返回。
+    const dp = new DelayedPromise<void>()
     const visitor = new StreamVisitor({
       onFinish: () => {
         nextTick(() => {
+          dp.resolve()
           handler.onDone()
         })
       }
@@ -434,6 +438,8 @@ export class CustomAgentModelProvider extends BaseModelProvider {
       },
       { deep: true }
     )
+
+    return dp.promise
   }
 
   /** 同步请求不需要实现 */

--- a/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
+++ b/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
@@ -395,6 +395,9 @@ export class CustomAgentModelProvider extends BaseModelProvider {
           dp.resolve()
           handler.onDone()
         })
+      },
+      onError: (error) => {
+        dp.reject(error)
       }
     })
     const streamContent = await visitor.traverse(result)

--- a/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
+++ b/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
@@ -390,19 +390,17 @@ export class CustomAgentModelProvider extends BaseModelProvider {
     // 待返回的promise对象，用户阻塞住函数立即返回。
     const dp = new DelayedPromise<void>()
     const visitor = new StreamVisitor({
+      debug: true,
       onFinish: () => {
         nextTick(() => {
           dp.resolve()
           handler.onDone()
         })
       },
-      onError: (error) => {
-        dp.reject(error)
-      }
+      onError: (error) => dp.reject(error),
+      onAbort: () => dp.reject('')
     })
     const streamContent = await visitor.traverse(result)
-
-    console.log(streamContent)
 
     const defaultMessage = {
       role: 'assistant',

--- a/packages/next-remoter/src/composable/streamVisitor.ts
+++ b/packages/next-remoter/src/composable/streamVisitor.ts
@@ -7,6 +7,7 @@ export interface StreamVisitorOption {
   onText?: (content: TextContent) => void
   onTool?: (content: ToolContent) => void
   onFinish?: () => void
+  onError?: (error: any) => void
 }
 
 export interface StartContent {
@@ -183,6 +184,7 @@ export class StreamVisitor {
             break
           case 'error':
             startContent!.error = event.error as any
+            this.option.onError?.(event.error as any)
             break
           default:
             // 忽略未知事件

--- a/packages/next-remoter/src/composable/streamVisitor.ts
+++ b/packages/next-remoter/src/composable/streamVisitor.ts
@@ -1,6 +1,7 @@
 import type { FinishReason, LanguageModelRequestMetadata, LanguageModelUsage, StreamTextResult } from 'ai'
 import { reactive, ref } from 'vue'
 export interface StreamVisitorOption {
+  debug?: boolean
   onStart?: (content: StartContent) => void
   onStep?: (content: StepContent) => void
   onReasoning?: (content: ReasoningContent) => void
@@ -8,6 +9,7 @@ export interface StreamVisitorOption {
   onTool?: (content: ToolContent) => void
   onFinish?: () => void
   onError?: (error: any) => void
+  onAbort?: () => void
 }
 
 export interface StartContent {
@@ -77,6 +79,9 @@ export class StreamVisitor {
 
   async traverse(stream: StreamTextResult<{}, never>) {
     const result = ref<StartContent>()
+    if (this.option.debug) {
+      console.log('【stream-debug】 响应对象体：', result)
+    }
 
     const backgroundRun = async () => {
       let startContent: StartContent
@@ -85,6 +90,10 @@ export class StreamVisitor {
       let textContent: TextContent
       let toolContent: ToolContent
       for await (const event of stream.fullStream) {
+        if (this.option.debug) {
+          console.log('【stream-debug】 ' + event.type, event)
+        }
+
         switch (event.type) {
           case 'start':
             startContent = reactive({
@@ -185,6 +194,12 @@ export class StreamVisitor {
           case 'error':
             startContent!.error = event.error as any
             this.option.onError?.(event.error as any)
+            break
+          case 'abort':
+            if (startContent) {
+              startContent.running = false
+            }
+            this.option.onAbort?.()
             break
           default:
             // 忽略未知事件

--- a/packages/next-remoter/src/composable/useTinyRobotChat.ts
+++ b/packages/next-remoter/src/composable/useTinyRobotChat.ts
@@ -52,7 +52,9 @@ export const useTinyRobotChat = ({ systemPrompt, llmConfig }: useTinyRobotOption
         if (messages.value[messages.value.length - 1].role === 'assistant') {
           messages.value.pop()
         }
-        messages.value.push(data)
+        if (data.uiContent.length > 0) {
+          messages.value.push(data)
+        }
       }
     }
   })

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ catalog:
   '@ai-sdk/openai': ^3.0.0
   '@ai-sdk/provider': ^3.0.0
   '@built-in-ai/core': ^2.1.0
+  '@ai-sdk/provider-utils': ^4.0.14
   ai: ^6.0.0
 
   # mcp


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/next-sdk/blob/dev/CONTRIBUTING.md#pull-request-specification)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation-related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stream completion now reliably waits for all streaming data before resolving.
  * Improved error and abort handling for streaming so failures are captured and surfaced.

* **New Features**
  * Optional debug mode for streaming to emit detailed event logs.
  * New callbacks to handle stream errors and aborts programmatically.

* **Chores**
  * Added a provider utilities package dependency to support the above behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->