### PR TITLE
fix: 将skill内容追加到系统提示词中

### DIFF
--- a/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
+++ b/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
@@ -393,7 +393,7 @@ export class CustomAgentModelProvider extends BaseModelProvider {
       // 合并用户传递的 providerOptions 与默认 GENUI_CONFIG，用户配置优先
       providerOptions: mergeProviderOptions(this.llmConfig.providerOptions, GENUI_CONFIG),
       prepareStep: ({ messages }: { messages: any[] }) => {
-        // 1. 清除get-skill-content的消息（暂时无法修改systemPrompt,先屏蔽)
+        // 1. 清除get-skill-content的消息
         this.cleanGetSkillContentToolResult(messages)
 
         // 2.在步骤开始前清理旧的快照消息

--- a/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
+++ b/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
@@ -180,9 +180,7 @@ export class CustomAgentModelProvider extends BaseModelProvider {
     if (lastMsg.role === 'tool' && lastMsg.content.length > 0) {
       const lastContent = lastMsg.content[lastMsg.content.length - 1]
       if (lastContent.type === 'tool-result' && lastContent.toolName === 'get_skill_content') {
-        lastContent.output.value.content = '查询到技能内容，并已添加到系统提示词中。'
-
-        messages.unshift({ role: 'system', content: this.promptManager.getSystemPrompt() })
+        lastContent.output.value.content = '查询到技能内容已添加到系统提示词中。'
       }
     }
   }
@@ -396,11 +394,12 @@ export class CustomAgentModelProvider extends BaseModelProvider {
       providerOptions: mergeProviderOptions(this.llmConfig.providerOptions, GENUI_CONFIG),
       prepareStep: ({ messages }: { messages: any[] }) => {
         // 1. 清除get-skill-content的消息（暂时无法修改systemPrompt,先屏蔽)
-        // this.cleanGetSkillContentToolResult(messages)
+        this.cleanGetSkillContentToolResult(messages)
 
         // 2.在步骤开始前清理旧的快照消息
         const cleanedMessages = this.cleanupOldSnapshotsInMessages(messages)
         return {
+          system: this.promptManager.getSystemPrompt(),
           messages: cleanedMessages
         }
       },

--- a/packages/next-wxt/components.d.ts
+++ b/packages/next-wxt/components.d.ts
@@ -9,6 +9,5 @@ declare module 'vue' {
   export interface GlobalComponents {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
-    VanIcon: typeof import('vant/es')['Icon']
   }
 }


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)
fix: 将skill内容追加到系统提示词中
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/next-sdk/blob/dev/CONTRIBUTING.md#pull-request-specification)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation-related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simplified confirmation message when skill content is added to system prompts.

* **Refactor**
  * System prompt handling made explicit in the message preparation workflow for more predictable behavior.

* **Breaking Changes**
  * A previously available global icon component is no longer exposed via the global declarations; adjust usages accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->