### PR TITLE
feat: Improve sessionId handling for flexibility in remoter components

### DIFF
--- a/docs/guide/angular-webmcp-best-practice.md
+++ b/docs/guide/angular-webmcp-best-practice.md
@@ -209,7 +209,7 @@ export const createMcpServer = async () => {
 }
 ```
 
-工具定义（`product-guide/tools.ts`、`price-protection/tools.ts`）与 Vue 版一致：`server.registerTool(name, schema, { route: '/path' })`，此处不再重复。
+工具定义（`product-guide/tools.ts`、`price-protection/tools.ts`）与 Vue 版一致：`server.registerTool(name, schema, { route: '/path', timeout?: number })`。其中 `timeout` 为可选，表示等待页面响应的超时时间（ms），默认 30000。此处不再重复。
 
 ---
 

--- a/docs/guide/api-createRemoter.md
+++ b/docs/guide/api-createRemoter.md
@@ -34,7 +34,7 @@ const remoter = createRemoter({
 
 | 参数         | 类型             | 必填 | 默认值                                     | 说明                   |
 | ------------ | ---------------- | ---- | ------------------------------------------ | ---------------------- |
-| sessionId    | string           | ✅   | -                                          | 被遥控页面的会话ID     |
+| sessionId    | string           | ❌   | -                                          | 被遥控页面的会话ID；不传时仅显示「打开对话框」，不显示扫码/识别码/遥控器链接 |
 | qrCodeUrl    | string           | ❌   | https:\/\/ai.opentiny.design\/next-remoter | 遥控端页面地址         |
 | logoUrl      | string           | ❌   | -                                          | 悬浮AI LogUrl地址      |
 | onShowAIChat | function         | ❌   | -                                          | 显示AI对话框的回调函数 |

--- a/docs/guide/vue-webmcp-best-practice.md
+++ b/docs/guide/vue-webmcp-best-practice.md
@@ -231,7 +231,9 @@ export default registerPriceProtectionTools
 > | 方式 | 第三个参数 | 适用场景 |
 > |------|-----------|---------|
 > | 回调函数 | `async (input) => { return { content: [...] } }` | 工具逻辑简单，不需要访问页面状态或 Vue 响应式数据 |
-> | 路由配置 | `{ route: '/some-path' }` | 工具需要读写页面状态，或需要在特定页面内执行业务逻辑 |
+> | 路由配置 | `{ route: '/some-path', timeout?: number }` | 工具需要读写页面状态，或需要在特定页面内执行业务逻辑 |
+>
+> 路由配置对象（RouteConfig）支持字段：**route**（必填，目标路由路径）、**timeout**（可选，等待页面响应的超时时间，单位 ms，默认 30000）。
 
 ---
 

--- a/packages/doc-ai/src/App.vue
+++ b/packages/doc-ai/src/App.vue
@@ -9,8 +9,8 @@
       class="remoter-pane"
       :skills="skillMdModules"
       :show="show"
-      :menuItems="menuItems"
       :mcpServers="mcpServers"
+      :sessionId="sessionId"
       layoutMode="relative"
     />
   </div>
@@ -18,10 +18,8 @@
 
 <script setup lang="ts">
 import { TinyRemoter } from '@opentiny/next-remoter'
-import type { MenuItemConfig } from '@opentiny/next-sdk'
 import { onMounted, ref } from 'vue'
 import { createMcpServer, clientTransport } from './mcp-servers'
-const menuItems = ref<MenuItemConfig[]>([])
 const show = ref(true)
 
 // 高兼容：同时匹配常见位置的 skills 目录，合并后直接传给 remoter，next-sdk 内部会统一处理 key

--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-remoter",
-  "version": "0.2.6-beta.1",
+  "version": "0.2.7",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/tiny-robot-remoter.html",
   "repository": {

--- a/packages/next-remoter/src/components/TinyRobotChat.vue
+++ b/packages/next-remoter/src/components/TinyRobotChat.vue
@@ -198,10 +198,10 @@ defineOptions({
 })
 
 const props = defineProps({
-  /** 必传的会话id */
+  /** 会话 id，可选；未传时仅显示「打开对话框」，不展示扫码等菜单 */
   sessionId: {
     type: String,
-    default: ''
+    default: undefined
   },
   /** 后端的代理服务器地址 */
   agentRoot: {

--- a/packages/next-remoter/src/composable/usePluginSession.ts
+++ b/packages/next-remoter/src/composable/usePluginSession.ts
@@ -7,7 +7,11 @@ import type { MenuItemConfig } from '@opentiny/next-sdk'
  * 用于处理 sessionId 相关的所有逻辑：扫码添加插件、识别码输入、遥控器初始化等
  */
 export function usePluginSession(options: {
-  /** 未设置(undefined)时立即创建简化菜单；配置了(ref)时等 value 有值后再创建完整菜单 */
+  /**
+   * 会话 ID：
+   * - 初始为 undefined 或空字符串时：先渲染仅含「打开对话框」的 Logo
+   * - 后续变为非空字符串时：自动升级为带二维码 / 遥控器等完整菜单
+   */
   sessionId: Ref<string | undefined>
   agentRoot: string
   mode: string
@@ -32,8 +36,9 @@ export function usePluginSession(options: {
     inputMessage
   } = options
 
-  // 遥控器是否已创建（只创建一次）
-  let isCreateRemoter = false
+  // remoter 实例 & 是否已经以「有 sessionId」的方式创建过
+  let remoterInstance: ReturnType<typeof createRemoter> | null = null
+  let createdWithSessionId = false
 
   /**
    * 处理扫码成功，添加插件
@@ -97,22 +102,20 @@ export function usePluginSession(options: {
 
   /**
    * 初始化遥控器模式：mode=remoter 时创建右下角 AI Logo
-   * - sessionId 未设置(undefined)：立即创建，仅显示「打开对话框」
-   * - sessionId 已配置(ref)：等 value 有值后再创建，显示完整菜单（扫码、识别码、遥控器链接）
+   * - 初始 sessionId 为空串 / undefined：立即创建，仅显示「打开对话框」
+   * - 后续 sessionId 变为非空字符串：销毁旧实例并重建，展示完整菜单（扫码、识别码、遥控器链接）
    */
   const initializeRemoter = () => {
     watch(
       sessionId,
       (value) => {
-        if (mode !== 'remoter' || isCreateRemoter) return
+        if (mode !== 'remoter') return
 
-        // 未设置：value 为 undefined，立即创建简化菜单
-        const notConfigured = value === undefined
-        // 已配置：等 value 有值再创建完整菜单
-        const hasValue = !!value
+        const hasSession = !!value
 
-        if (notConfigured || hasValue) {
-          createRemoter({
+        if (!remoterInstance) {
+          // 首次创建：sessionId 可能为空串 / undefined，此时只展示「打开对话框」
+          remoterInstance = createRemoter({
             sessionId: value || undefined,
             qrCodeUrl,
             remoteUrl,
@@ -120,7 +123,19 @@ export function usePluginSession(options: {
             logoUrl: AILogoUrl,
             onShowAIChat: () => (show.value = true)
           })
-          isCreateRemoter = true
+          createdWithSessionId = hasSession
+        } else if (!createdWithSessionId && hasSession) {
+          // 之前以「无 sessionId」创建，现在拿到真正 sessionId：重建以展示完整菜单
+          remoterInstance.destroy()
+          remoterInstance = createRemoter({
+            sessionId: value,
+            qrCodeUrl,
+            remoteUrl,
+            menuItems,
+            logoUrl: AILogoUrl,
+            onShowAIChat: () => (show.value = true)
+          })
+          createdWithSessionId = true
         }
       },
       { immediate: true }

--- a/packages/next-remoter/src/composable/usePluginSession.ts
+++ b/packages/next-remoter/src/composable/usePluginSession.ts
@@ -7,7 +7,8 @@ import type { MenuItemConfig } from '@opentiny/next-sdk'
  * 用于处理 sessionId 相关的所有逻辑：扫码添加插件、识别码输入、遥控器初始化等
  */
 export function usePluginSession(options: {
-  sessionId: Ref<string>
+  /** 未设置(undefined)时立即创建简化菜单；配置了(ref)时等 value 有值后再创建完整菜单 */
+  sessionId: Ref<string | undefined>
   agentRoot: string
   mode: string
   qrCodeUrl?: string
@@ -31,7 +32,7 @@ export function usePluginSession(options: {
     inputMessage
   } = options
 
-  // 遥控器是否已创建（确保只创建一次）
+  // 遥控器是否已创建（只创建一次）
   let isCreateRemoter = false
 
   /**
@@ -95,22 +96,30 @@ export function usePluginSession(options: {
   }
 
   /**
-   * 初始化遥控器模式
+   * 初始化遥控器模式：mode=remoter 时创建右下角 AI Logo
+   * - sessionId 未设置(undefined)：立即创建，仅显示「打开对话框」
+   * - sessionId 已配置(ref)：等 value 有值后再创建，显示完整菜单（扫码、识别码、遥控器链接）
    */
   const initializeRemoter = () => {
     watch(
       sessionId,
       (value) => {
-        if (value && mode === 'remoter' && !isCreateRemoter) {
+        if (mode !== 'remoter' || isCreateRemoter) return
+
+        // 未设置：value 为 undefined，立即创建简化菜单
+        const notConfigured = value === undefined
+        // 已配置：等 value 有值再创建完整菜单
+        const hasValue = !!value
+
+        if (notConfigured || hasValue) {
           createRemoter({
-            sessionId: value,
+            sessionId: value || undefined,
             qrCodeUrl,
             remoteUrl,
             menuItems,
             logoUrl: AILogoUrl,
             onShowAIChat: () => (show.value = true)
           })
-
           isCreateRemoter = true
         }
       },

--- a/packages/next-sdk/package.json
+++ b/packages/next-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-sdk",
-  "version": "0.2.6-beta.2",
+  "version": "0.2.7",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/",
   "repository": {

--- a/packages/next-sdk/page-tool-bridge.ts
+++ b/packages/next-sdk/page-tool-bridge.ts
@@ -17,7 +17,7 @@
  *
  *   // mcp-servers/product-guide/tools.ts
  *   server.registerTool('product-guide', { title, description, inputSchema },
- *     { route: '/comprehensive' }            // ← 路由配置对象，替代回调函数
+ *     { route: '/comprehensive', timeout: 15000 }  // ← 路由配置：route 必填，timeout 可选（ms，默认 30000）
  *   )
  *   // 或仍然使用普通回调（完全兼容）
  *   server.registerTool('simple-tool', { ... }, async (input) => { ... })
@@ -306,8 +306,8 @@ function buildPageHandler(name: string, route: string, timeout = 30000) {
  * @example
  * const server = withPageTools(new WebMcpServer())
  *
- * // 路由模式：第三个参数传路由配置
- * server.registerTool('product-guide', { title, inputSchema }, { route: '/comprehensive' })
+ * // 路由模式：第三个参数传路由配置（route 必填，timeout 可选，单位 ms，默认 30000）
+ * server.registerTool('product-guide', { title, inputSchema }, { route: '/comprehensive', timeout: 15000 })
  *
  * // 普通模式：第三个参数传回调（兼容原有写法）
  * server.registerTool('simple-tool', { title }, async (input) => ({ content: [...] }))

--- a/packages/next-sdk/remoter/createRemoter.ts
+++ b/packages/next-sdk/remoter/createRemoter.ts
@@ -39,8 +39,8 @@ export interface FloatingBlockOptions {
 
   /** 遥控端页面地址，默认为： https://ai.opentiny.design/next-remoter */
   qrCodeUrl?: string
-  /** 被遥控页面的 sessionId, 必填 */
-  sessionId: string
+  /** 被遥控页面的 sessionId；无 sessionId 时仅显示「打开对话框」菜单，不显示二维码、识别码、遥控器链接 */
+  sessionId?: string
   /** 菜单项配置 */
   menuItems?: MenuItemConfig[]
   /** 遥控端页面地址，默认为： https://chat.opentiny.design */
@@ -52,11 +52,13 @@ export interface FloatingBlockOptions {
 // 动作类型
 export type ActionType = 'qr-code' | 'ai-chat' | 'remote-control' | 'remote-url'
 
+/** 有 sessionId 时的完整菜单；无 sessionId 时仅返回 ai-chat（不依赖会话的菜单项） */
 const getDefaultMenuItems = (options: FloatingBlockOptions): MenuItemConfig[] => {
-  return [
+  const hasSession = !!options.sessionId
+  const baseItems: MenuItemConfig[] = [
     {
       action: 'qr-code',
-      show: true,
+      show: hasSession,
       text: '扫码登录',
       desc: '使用手机遥控页面',
       icon: qrCode
@@ -70,7 +72,7 @@ const getDefaultMenuItems = (options: FloatingBlockOptions): MenuItemConfig[] =>
     },
     {
       action: 'remote-url',
-      show: true,
+      show: hasSession,
       text: `遥控器链接`,
       desc: `${options.remoteUrl}`,
       active: true,
@@ -80,14 +82,15 @@ const getDefaultMenuItems = (options: FloatingBlockOptions): MenuItemConfig[] =>
     },
     {
       action: 'remote-control',
-      show: true,
+      show: hasSession,
       text: `识别码`,
-      desc: `${options.sessionId.slice(-6)}`,
+      desc: hasSession ? `${options.sessionId!.slice(-6)}` : '',
       know: true,
       showCopyIcon: true,
       icon: scan
     }
   ]
+  return baseItems
 }
 
 class FloatingBlock {
@@ -105,10 +108,6 @@ class FloatingBlock {
   }
 
   constructor(options: FloatingBlockOptions) {
-    if (!options.sessionId) {
-      throw new Error('sessionId is required')
-    }
-
     this.options = {
       ...options,
       qrCodeUrl: options.qrCodeUrl || DEFAULT_QR_CODE_URL,
@@ -146,27 +145,30 @@ class FloatingBlock {
   }
 
   /**
-   * 合并菜单项配置
-   * @param userMenuItems 用户自定义菜单项配置
-   * @returns 合并后的菜单项配置
+   * 合并菜单项配置；无 sessionId 时依赖会话的菜单项（qr-code/remote-url/remote-control）强制不显示
    */
   private mergeMenuItems(userMenuItems?: MenuItemConfig[]): MenuItemConfig[] {
+    const sessionDependentActions: ActionType[] = ['qr-code', 'remote-url', 'remote-control']
+    const forceHide = (item: MenuItemConfig) =>
+      !this.options.sessionId && sessionDependentActions.includes(item.action) ? { ...item, show: false } : item
+
     if (!userMenuItems) {
-      return getDefaultMenuItems(this.options)
+      return getDefaultMenuItems(this.options).map(forceHide)
     }
 
-    return getDefaultMenuItems(this.options).map((defaultItem) => {
-      const userItem = userMenuItems.find((item) => item.action === defaultItem.action)
-      if (userItem) {
-        return {
-          ...defaultItem,
-          ...userItem,
-          // 确保show属性存在，默认为true
-          show: userItem.show !== undefined ? userItem.show : defaultItem.show
+    return getDefaultMenuItems(this.options)
+      .map((defaultItem) => {
+        const userItem = userMenuItems.find((item) => item.action === defaultItem.action)
+        if (userItem) {
+          return {
+            ...defaultItem,
+            ...userItem,
+            show: userItem.show !== undefined ? userItem.show : defaultItem.show
+          }
         }
-      }
-      return defaultItem
-    })
+        return defaultItem
+      })
+      .map(forceHide)
   }
 
   private init(): void {
@@ -354,10 +356,12 @@ class FloatingBlock {
   }
 
   private copyRemoteControl(): void {
+    if (!this.options.sessionId) return
     this.copyToClipboard(this.options.sessionId.slice(-6))
   }
 
   private copyRemoteURL(): void {
+    if (!this.options.sessionId) return
     this.copyToClipboard(this.options.remoteUrl + this.sessionPrefix + this.options.sessionId)
   }
 
@@ -417,8 +421,9 @@ class FloatingBlock {
     }, 1500)
   }
 
-  // 创建二维码弹窗
+  // 创建二维码弹窗（无 sessionId 时不展示）
   private async showQRCode(): Promise<void> {
+    if (!this.options.sessionId) return
     const qrCode = new QrCode((this.options.qrCodeUrl || '') + this.sessionPrefix + this.options.sessionId, {})
     const base64 = await qrCode.toDataURL()
     const modal = this.createModal(

--- a/packages/next-sdk/remoter/createRemoter.ts
+++ b/packages/next-sdk/remoter/createRemoter.ts
@@ -145,15 +145,18 @@ class FloatingBlock {
   }
 
   /**
-   * 合并菜单项配置；无 sessionId 时依赖会话的菜单项（qr-code/remote-url/remote-control）强制不显示
+   * 合并菜单项配置。
+   * - 有 sessionId：使用默认菜单 + 用户配置（可定制每一项的 show/text/icon 等）
+   * - 无 sessionId：不渲染任何下拉菜单，仅保留点击浮标打开对话框的能力
    */
   private mergeMenuItems(userMenuItems?: MenuItemConfig[]): MenuItemConfig[] {
-    const sessionDependentActions: ActionType[] = ['qr-code', 'remote-url', 'remote-control']
-    const forceHide = (item: MenuItemConfig) =>
-      !this.options.sessionId && sessionDependentActions.includes(item.action) ? { ...item, show: false } : item
+    // 无 sessionId：完全关闭下拉菜单（包括 ai-chat 项），只保留点击浮标触发 onShowAIChat
+    if (!this.options.sessionId) {
+      return []
+    }
 
     if (!userMenuItems) {
-      return getDefaultMenuItems(this.options).map(forceHide)
+      return getDefaultMenuItems(this.options)
     }
 
     return getDefaultMenuItems(this.options)
@@ -168,7 +171,6 @@ class FloatingBlock {
         }
         return defaultItem
       })
-      .map(forceHide)
   }
 
   private init(): void {


### PR DESCRIPTION
feat: 改进 sessionId 处理，以提高远程组件的灵活性

# Pull Request (OpenTiny NEXT-SDKs)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/next-sdk/blob/dev/CONTRIBUTING.md#pull-request-specification)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation-related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional timeout parameter to configure maximum wait time for page responses (default: 30s).

* **Improvements**
  * sessionId is now optional; when absent the UI shows a simplified "Open dialog" menu and hides QR code, remote link, and remote-control options. Actions that rely on sessionId are disabled when unavailable.

* **Documentation**
  * Updated guides and API docs to describe timeout and optional sessionId behavior.

* **Chores**
  * Version bumped to 0.2.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->