### PR TITLE
feat: Support custom request headers in mcp-servers

### DIFF
--- a/docs/guide/tiny-robot-remoter.md
+++ b/docs/guide/tiny-robot-remoter.md
@@ -441,6 +441,26 @@ const customMarketMcpServers = [
 
 组件初始化时会把上述数组与 `DEFAULT_SERVERS` 合并，因此你可以通过简单传参扩展默认市场。
 
+#### 自定义 MCP 请求 Header (headers)
+
+`customMarketMcpServers` 中的每个配置项也支持 `headers` 字段，用于向该 MCP 服务器发起请求时携带自定义 Header：
+
+```ts
+const customMarketMcpServers = [
+  {
+    id: 'ppt-mcp',
+    name: 'PPT文档MCP服务器',
+    // ... 其他配置
+    url: 'https://your-mcp-server-url.com/mcp',
+    type: 'streamableHttp',
+    // 自定义请求 Header
+    headers: {
+      'Authorization': 'Bearer your-mcp-token'
+    }
+  }
+]
+```
+
 ## 预置 MCP 服务器（mcpServers）
 
 `mcpServers` 属性用于在组件初始化时预置一批 MCP 服务器，采用业界通用的对象格式：**键为服务器名称，值为 `McpServerConfig`**。**一般用于接入前端的 MCP 服务，生命周期与页面一致，页面关闭后连接即断开。** 这些服务器会在启动时自动加载并出现在「已添加MCP服务」中，无需用户从市场手动添加。
@@ -452,7 +472,11 @@ const customMarketMcpServers = [
 const mcpServers = {
   'my-app-mcp-server': {
     type: 'streamableHttp',
-    url: 'https://agent.opentiny.design/api/v1/webmcp-trial/mcp?sessionId=stream06-1921-4f09-af63-51de410e9e09'
+    url: 'https://agent.opentiny.design/api/v1/webmcp-trial/mcp?sessionId=xxx',
+    // 支持配置自定义 Header
+    headers: {
+      'X-Project-Id': 'project-456'
+    }
   },
   'local-mcp-server': {
     type: 'local',
@@ -463,8 +487,8 @@ const mcpServers = {
 
 `McpServerConfig` 支持以下类型（与 next-sdk 一致）：
 
-- `type: 'streamableHttp'` 或 `type: 'sse'`：需提供 `url`，可选 `useAISdkClient`
-- `type: 'extension'`：需提供 `url`、`sessionId`，可选 `useAISdkClient`
+- `type: 'streamableHttp'` 或 `type: 'sse'`：需提供 `url`，可选 `useAISdkClient` 和 `headers`
+- `type: 'extension'`：需提供 `url`、`sessionId`，可选 `useAISdkClient` 和 `headers`
 - `type: 'local'`：需提供 `transport`（MCP 传输层），可选 `useAISdkClient`
 
 ## 页面工具按需加载（pageToolsOnDemand）

--- a/docs/guide/tiny-robot-remoter.md
+++ b/docs/guide/tiny-robot-remoter.md
@@ -441,7 +441,7 @@ const customMarketMcpServers = [
 
 组件初始化时会把上述数组与 `DEFAULT_SERVERS` 合并，因此你可以通过简单传参扩展默认市场。
 
-#### 自定义 MCP 请求 Header (headers)
+### 自定义 MCP 请求 Header (headers)
 
 `customMarketMcpServers` 中的每个配置项也支持 `headers` 字段，用于向该 MCP 服务器发起请求时携带自定义 Header：
 

--- a/packages/next-remoter/src/composable/useCustomMcpServer.ts
+++ b/packages/next-remoter/src/composable/useCustomMcpServer.ts
@@ -39,7 +39,7 @@ const normalizeMcpConfig = (config: any): McpServerConfig | null => {
     return null
   }
 
-  const { type, url, sessionId } = config
+  const { type, url, sessionId, headers } = config
 
   // extension 类型需要 sessionId
   if (type === 'extension') {
@@ -50,6 +50,7 @@ const normalizeMcpConfig = (config: any): McpServerConfig | null => {
       type: 'extension',
       url,
       sessionId,
+      headers,
       useAISdkClient: true
     } as McpServerConfig
   }
@@ -59,6 +60,7 @@ const normalizeMcpConfig = (config: any): McpServerConfig | null => {
     return {
       type,
       url,
+      headers,
       useAISdkClient: true
     } as McpServerConfig
   }
@@ -67,6 +69,7 @@ const normalizeMcpConfig = (config: any): McpServerConfig | null => {
   return {
     type: 'streamableHttp',
     url,
+    headers,
     useAISdkClient: true
   } as McpServerConfig
 }
@@ -226,9 +229,22 @@ export const useCustomMcpServer = (
       const pluginId = `custom-${name}-${Date.now()}`
       const serverName = `mcp-server-${pluginId}`
 
+      // 解析 headers
+      let headers: Record<string, string> | undefined = undefined
+      if (typeof _headers === 'string' && _headers.trim()) {
+        try {
+          headers = JSON.parse(_headers)
+        } catch (e) {
+          console.warn('Failed to parse headers JSON:', e)
+        }
+      } else if (typeof _headers === 'object') {
+        headers = _headers as Record<string, string>
+      }
+
       const mcpServer: McpServerConfig = {
         type: mcpType as 'streamableHttp' | 'sse',
         url,
+        headers,
         useAISdkClient: true
       } as McpServerConfig
 

--- a/packages/next-remoter/src/composable/usePlugin.ts
+++ b/packages/next-remoter/src/composable/usePlugin.ts
@@ -271,6 +271,7 @@ export function usePlugin(
     const mcpServer = {
       type: (plugin as any).type,
       url: (plugin as any).url,
+      headers: (plugin as any).headers,
       useAISdkClient: true
     } as McpServerConfig
 

--- a/packages/next-sdk/agent/AgentModelProvider.ts
+++ b/packages/next-sdk/agent/AgentModelProvider.ts
@@ -2,6 +2,7 @@ import { streamText, stepCountIs, generateText } from 'ai'
 import { MCPClientConfig, createMCPClient } from '@ai-sdk/mcp'
 import type { ToolSet } from 'ai'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import type { IAgentModelProviderOption, McpServerConfig } from './type'
 import { ProviderV2 } from '@ai-sdk/provider'
@@ -81,15 +82,21 @@ export class AgentModelProvider {
   private async _createOneClient(serverConfig: McpServerConfig) {
     try {
       let transport: MCPClientConfig['transport']
-      // transport 一定是 streamableHttp 或者就是： ai-sdk允许的 transport
+      // transport 一定是 streamableHttp/sse 或者就是： ai-sdk允许的 transport
       if ('type' in serverConfig && serverConfig.type.toLocaleLowerCase() === 'streamablehttp') {
-        transport = new StreamableHTTPClientTransport(new URL((serverConfig as { url: string }).url))
+        const configWithHeaders = serverConfig as { url: string; headers?: Record<string, string> }
+        const requestInit = configWithHeaders.headers ? { headers: configWithHeaders.headers } : undefined
+        transport = new StreamableHTTPClientTransport(new URL(configWithHeaders.url), { requestInit })
+      } else if ('type' in serverConfig && serverConfig.type === 'sse') {
+        const configWithHeaders = serverConfig as { url: string; headers?: Record<string, string> }
+        const requestInit = configWithHeaders.headers ? { headers: configWithHeaders.headers } : undefined
+        transport = new SSEClientTransport(new URL(configWithHeaders.url), { requestInit })
       } else if ('type' in serverConfig && serverConfig.type === 'extension') {
         transport = new ExtensionClientTransport(serverConfig.sessionId)
       } else if ('transport' in serverConfig) {
         transport = serverConfig.transport
       } else {
-        transport = serverConfig as MCPClientConfig['transport']
+        transport = serverConfig as unknown as MCPClientConfig['transport']
       }
 
       // 根据 useAISdkClient 配置决定使用哪种 client 创建方式

--- a/packages/next-sdk/agent/type.ts
+++ b/packages/next-sdk/agent/type.ts
@@ -35,9 +35,9 @@ export type IAgentModelProviderLlmConfig = LlmFactoryConfig | LlmInstanceConfig
 
 /** Mcp Server的配置对象 */
 export type McpServerConfig =
-  | { type: 'streamableHttp'; url: string; useAISdkClient?: boolean }
-  | { type: 'sse'; url: string; useAISdkClient?: boolean }
-  | { type: 'extension'; url: string; sessionId: string; useAISdkClient?: boolean }
+  | { type: 'streamableHttp'; url: string; useAISdkClient?: boolean; headers?: Record<string, string> }
+  | { type: 'sse'; url: string; useAISdkClient?: boolean; headers?: Record<string, string> }
+  | { type: 'extension'; url: string; sessionId: string; useAISdkClient?: boolean; headers?: Record<string, string> }
   | { type: 'local'; transport: MCPTransport; useAISdkClient?: boolean }
 
 /** */


### PR DESCRIPTION
feat: mcp-servers 支持自定义请求头
# Pull Request (OpenTiny NEXT-SDKs)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/next-sdk/blob/dev/CONTRIBUTING.md#pull-request-specification)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation-related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying custom HTTP request headers for MCP server connections (streamableHttp, SSE, and extension).
  * Server header values may be provided as JSON objects or JSON strings; invalid JSON is detected and handled gracefully.

* **Documentation**
  * Updated guide with examples and schema notes showing how to include custom headers when configuring MCP servers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->