### PR TITLE
fix: 修复历史会话无法保存的问题

### DIFF
--- a/packages/next-remoter/src/components/TinyRobotChat.vue
+++ b/packages/next-remoter/src/components/TinyRobotChat.vue
@@ -321,10 +321,10 @@ const props = defineProps({
 const emit = defineEmits<{
   /** 在 AI 消息渲染之前触发，用户此时可以修改消息内容
    *  uiContent包含当前流返回的消息类型：markdown, reasoning,tool,或其它自定义的消息。
-   * 
+   *
    * @param currMessage - 当前消息对象，包含 role , content, uiContent 字段。
    */
-  (e: 'before-ai-render', currMessage: { role: string; content: string ,uiContent:any[]}): void
+  (e: 'before-ai-render', currMessage: { role: string; content: string; uiContent: any[] }): void
 }>()
 
 const fullscreen = defineModel('fullscreen', { type: Boolean, default: false })
@@ -602,7 +602,9 @@ initializePluginSession()
 
 onMounted(async () => {
   // 初始化会话（每次刷新都是新会话）
-  handleCreateConversation()
+  setTimeout(() => {
+    handleCreateConversation()
+  }, 100)
 
   // 统一报错
   agent.onError = (msg: string) => {

--- a/packages/next-remoter/src/composable/useConversationHistory.ts
+++ b/packages/next-remoter/src/composable/useConversationHistory.ts
@@ -55,6 +55,7 @@ export function useConversationHistory(options: {
     const aiSdkMessages: any[] = []
     customAgentProvider.agent.responseMessages = aiSdkMessages
 
+    debugger
     // 创建新会话
     createConversation()
 

--- a/packages/next-remoter/src/composable/useConversationHistory.ts
+++ b/packages/next-remoter/src/composable/useConversationHistory.ts
@@ -55,7 +55,6 @@ export function useConversationHistory(options: {
     const aiSdkMessages: any[] = []
     customAgentProvider.agent.responseMessages = aiSdkMessages
 
-    debugger
     // 创建新会话
     createConversation()
 

--- a/packages/next-remoter/src/composable/useTinyRobotChat.ts
+++ b/packages/next-remoter/src/composable/useTinyRobotChat.ts
@@ -83,7 +83,6 @@ export const useTinyRobotChat = ({ systemPrompt, llmConfig, emit }: useTinyRobot
 
     // 第一次发送时，修改会话标题
     const conv = getCurrentConversation()
-    debugger
     if (conv && conv.title === '新会话') {
       updateTitle(conv.id, inputMessage.value.slice(0, 15))
     }

--- a/packages/next-remoter/src/composable/useTinyRobotChat.ts
+++ b/packages/next-remoter/src/composable/useTinyRobotChat.ts
@@ -42,7 +42,7 @@ export const useTinyRobotChat = ({ systemPrompt, llmConfig, emit }: useTinyRobot
     state: conversationState // 记录着所有的会话和 currentId
   } = useConversation({
     client,
-    autoSave: false,
+    autoSave: true,
     events: {
       onLoaded() {
         // 会话加载完成（初始化将在组件的 onMounted 中调用）
@@ -83,6 +83,7 @@ export const useTinyRobotChat = ({ systemPrompt, llmConfig, emit }: useTinyRobot
 
     // 第一次发送时，修改会话标题
     const conv = getCurrentConversation()
+    debugger
     if (conv && conv.title === '新会话') {
       updateTitle(conv.id, inputMessage.value.slice(0, 15))
     }


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)
fix: 修复历史会话无法保存的问题

原因：

每次刷新先 create一个新会话并保存一下， 但此时 robot内部的load会话未执行， 所以保存时覆盖掉了上次的会话。
所以增加一个延时修复

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/next-sdk/blob/dev/CONTRIBUTING.md#pull-request-specification)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation-related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversations are now automatically saved.

* **Bug Fixes**
  * Adjusted initialization timing for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->