### PR TITLE
feat: 查询无障碍信息时，为可点击元素添加边框

### DIFF
--- a/packages/next-remoter/src/components/TinyRobotChat.vue
+++ b/packages/next-remoter/src/components/TinyRobotChat.vue
@@ -325,6 +325,7 @@ const emit = defineEmits<{
    * @param currMessage - 当前消息对象，包含 role , content, uiContent 字段。
    */
   (e: 'before-ai-render', currMessage: { role: string; content: string; uiContent: any[] }): void
+  (e: 'chat-stream-finish'): void
 }>()
 
 const fullscreen = defineModel('fullscreen', { type: Boolean, default: false })

--- a/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
+++ b/packages/next-remoter/src/composable/CustomAgentModelProvider.ts
@@ -63,8 +63,14 @@ export class CustomAgentModelProvider extends BaseModelProvider {
   /** 生成式UI启用状态 */
   isGenuiEnabled?: Ref<boolean>
   debugStream: boolean = false
+  emit: ((event: string, data: any) => void) | undefined
 
-  constructor(config: AIModelConfig, systemPrompt: string, llmConfig?: ICustomAgentModelProviderLlmConfig) {
+  constructor(
+    config: AIModelConfig,
+    systemPrompt: string,
+    llmConfig?: ICustomAgentModelProviderLlmConfig,
+    emit?: (event: string, data: any) => void
+  ) {
     super(config)
 
     let mergedConfig: ICustomAgentModelProviderLlmConfig
@@ -92,6 +98,7 @@ export class CustomAgentModelProvider extends BaseModelProvider {
     this.agent = new AgentModelProvider(options)
     this.promptManager = new PromptManager()
     this.promptManager.setStatic(systemPrompt)
+    this.emit = emit
   }
 
   /**
@@ -425,6 +432,7 @@ export class CustomAgentModelProvider extends BaseModelProvider {
       onFinish: async () => {
         await this.agent.closeAll()
         this.promptManager.setTemp('') // 清除临时skillPrompt的提示词
+        this.emit?.('chat-stream-finish')
       }
     }
 

--- a/packages/next-remoter/src/composable/useTinyRobotChat.ts
+++ b/packages/next-remoter/src/composable/useTinyRobotChat.ts
@@ -25,7 +25,7 @@ interface UIMessage {
 }
 
 export const useTinyRobotChat = ({ systemPrompt, llmConfig, emit }: useTinyRobotOption) => {
-  const customAgentProvider = new CustomAgentModelProvider({ provider: 'custom' }, systemPrompt, llmConfig)
+  const customAgentProvider = new CustomAgentModelProvider({ provider: 'custom' }, systemPrompt, llmConfig, emit)
 
   const client = new AIClient({
     providerImplementation: customAgentProvider,

--- a/packages/next-wxt/entrypoints/sidepanel/App.vue
+++ b/packages/next-wxt/entrypoints/sidepanel/App.vue
@@ -128,9 +128,12 @@ browser.runtime.onMessage.addListener((message) => {
 
 // 每一轮对话，都要清除一下页面高亮
 const clearHighlightPage =async () => {
-  // remoterRef.value.clearHighlightPage()
- const {manager}= await getSnapshotManager()
-  manager.highlightPage(false)
+  try {
+    const { manager } = await getSnapshotManager()
+    await manager.highlightPage(false)
+  } catch (error) {
+    console.error('清除页面高亮失败', error)
+  }
 }
 
 </script>

--- a/packages/next-wxt/entrypoints/sidepanel/App.vue
+++ b/packages/next-wxt/entrypoints/sidepanel/App.vue
@@ -13,6 +13,7 @@ import { CustomFunction } from '@/utils/customFunction'
 import { getModelConfigsWithToken } from './model-manage'
 import { getStorageItem, setStorageItem } from './utils/local-storage'
 import { StorageKeys } from './utils/storage-keys'
+import { getSnapshotManager } from './accessibility/utils'
 
 // 从统一入口读取 skills（built-in + 用户在 Options 中的覆盖）
 const skills = ref<Record<string, string>>({})
@@ -124,6 +125,14 @@ browser.runtime.onMessage.addListener((message) => {
     location.reload()
   }
 })
+
+// 每一轮对话，都要清除一下页面高亮
+const clearHighlightPage =async () => {
+  // remoterRef.value.clearHighlightPage()
+ const {manager}= await getSnapshotManager()
+  manager.highlightPage(false)
+}
+
 </script>
 
 <template>
@@ -143,6 +152,7 @@ browser.runtime.onMessage.addListener((message) => {
       :custom-market-mcp-servers="customMarketMcpServers"
       :gen-ui-components="genUiComponents"
       :skills="skills"
+      @chat-stream-finish="clearHighlightPage"
     >
       <template #header-actions>
         <button v-if="false" class="record-button" type="button" @click="openRecordModal">

--- a/packages/next-wxt/entrypoints/sidepanel/accessibility/index.ts
+++ b/packages/next-wxt/entrypoints/sidepanel/accessibility/index.ts
@@ -23,7 +23,7 @@ export async function executeSnapshotAction(params: SnapshotActionParams): Promi
     // 根据操作类型分发到不同的处理函数
     if (action === 'snapshot') {
       await handleSnapshotAction(manager)
-      manager.highlightPage(true) // 每一次查询无障碍，都高亮一次页面。
+      await manager.highlightPage(true) // 每一次查询无障碍，都高亮一次页面。
 
       return await handleSnapshotAction(manager)
     } else if (action === 'click') {

--- a/packages/next-wxt/entrypoints/sidepanel/accessibility/index.ts
+++ b/packages/next-wxt/entrypoints/sidepanel/accessibility/index.ts
@@ -22,7 +22,10 @@ export async function executeSnapshotAction(params: SnapshotActionParams): Promi
   try {
     // 根据操作类型分发到不同的处理函数
     if (action === 'snapshot') {
-      return await handleSnapshotAction(manager)
+      const result = await handleSnapshotAction(manager)
+      manager.highlightPage(true) // 每一次查询无障碍，都高亮一次页面。
+
+      return result
     } else if (action === 'click') {
       if (!params.uid) {
         throw new Error('点击操作需要提供 uid 参数')

--- a/packages/next-wxt/entrypoints/sidepanel/accessibility/index.ts
+++ b/packages/next-wxt/entrypoints/sidepanel/accessibility/index.ts
@@ -22,10 +22,10 @@ export async function executeSnapshotAction(params: SnapshotActionParams): Promi
   try {
     // 根据操作类型分发到不同的处理函数
     if (action === 'snapshot') {
-      const result = await handleSnapshotAction(manager)
+      await handleSnapshotAction(manager)
       manager.highlightPage(true) // 每一次查询无障碍，都高亮一次页面。
 
-      return result
+      return await handleSnapshotAction(manager)
     } else if (action === 'click') {
       if (!params.uid) {
         throw new Error('点击操作需要提供 uid 参数')

--- a/packages/next-wxt/entrypoints/sidepanel/extraTools.ts
+++ b/packages/next-wxt/entrypoints/sidepanel/extraTools.ts
@@ -5,6 +5,7 @@ import { getCurrentTabId, waitForTabLoad } from './utils/utils'
 import { withToolAnimation } from './utils/toolAnimationWrapper'
 import { executeVisualAction } from './visual'
 import { executeSnapshotAction } from './accessibility'
+import { getSnapshotManager } from './accessibility/utils'
 
 export const useExtraTools = (server: WebMcpServer) => {
   // 打开新网址
@@ -26,6 +27,11 @@ export const useExtraTools = (server: WebMcpServer) => {
     async ({ action, url, tabId }) => {
       if (action === 'open') {
         if (!url) return { content: [{ type: 'text', text: '打开新网址工具错误: 缺少网址参数' }] }
+
+        // 在打开新网址时，先尝试关闭当前页面的高亮
+        const { manager } = await getSnapshotManager()
+        manager.highlightPage(false)
+
         // 判断 URL 是否匹配
         const isUrlMatch = (tabUrl: string | undefined, targetUrl: string): boolean => {
           if (!tabUrl) return false
@@ -100,6 +106,10 @@ export const useExtraTools = (server: WebMcpServer) => {
       } else if (action === 'switch') {
         if (!tabId) return { content: [{ type: 'text', text: '切换标签页工具错误: 缺少标签页 ID 参数' }] }
 
+        // 在切换标签页时，先尝试关闭当前页面的高亮
+        const { manager } = await getSnapshotManager()
+        manager.highlightPage(false)
+
         try {
           await browser.tabs.update(tabId!, { active: true })
           return { content: [{ type: 'text', text: `已切换到标签页 ${tabId}` }] }
@@ -116,6 +126,10 @@ export const useExtraTools = (server: WebMcpServer) => {
           return { content: [{ type: 'text', text: `关闭标签页工具错误: ${error.message}` }] }
         }
       } else if (action === 'switch-pre-tab') {
+        // 在切换标签页时，先尝试关闭当前页面的高亮
+        const { manager } = await getSnapshotManager()
+        manager.highlightPage(false)
+
         try {
           await sendRuntimeMessage('active-pre-tab', {}, 'side->bg')
           return { content: [{ type: 'text' as const, text: '已激活上一个标签页' }] }

--- a/packages/next-wxt/entrypoints/sidepanel/extraTools.ts
+++ b/packages/next-wxt/entrypoints/sidepanel/extraTools.ts
@@ -30,7 +30,7 @@ export const useExtraTools = (server: WebMcpServer) => {
 
         // 在打开新网址时，先尝试关闭当前页面的高亮
         const { manager } = await getSnapshotManager()
-        manager.highlightPage(false)
+        await manager.highlightPage(false)
 
         // 判断 URL 是否匹配
         const isUrlMatch = (tabUrl: string | undefined, targetUrl: string): boolean => {
@@ -108,7 +108,7 @@ export const useExtraTools = (server: WebMcpServer) => {
 
         // 在切换标签页时，先尝试关闭当前页面的高亮
         const { manager } = await getSnapshotManager()
-        manager.highlightPage(false)
+        await manager.highlightPage(false)
 
         try {
           await browser.tabs.update(tabId!, { active: true })
@@ -128,7 +128,7 @@ export const useExtraTools = (server: WebMcpServer) => {
       } else if (action === 'switch-pre-tab') {
         // 在切换标签页时，先尝试关闭当前页面的高亮
         const { manager } = await getSnapshotManager()
-        manager.highlightPage(false)
+        await manager.highlightPage(false)
 
         try {
           await sendRuntimeMessage('active-pre-tab', {}, 'side->bg')

--- a/packages/next-wxt/entrypoints/sidepanel/utils/snapshotManager.ts
+++ b/packages/next-wxt/entrypoints/sidepanel/utils/snapshotManager.ts
@@ -234,7 +234,7 @@ export class SnapshotManager {
    * @param isHighlight 是否高亮
    */
   async highlightPage(isHighlight: boolean) {
-    if (this.currentSnapshot) {
+    if (!this.currentSnapshot) {
       await this.createTextSnapshot()
     }
 

--- a/packages/next-wxt/entrypoints/sidepanel/utils/snapshotManager.ts
+++ b/packages/next-wxt/entrypoints/sidepanel/utils/snapshotManager.ts
@@ -1,6 +1,7 @@
 import { connect, ExtensionTransport } from 'puppeteer-core/lib/esm/puppeteer/puppeteer-core-browser.js'
 import type { Page, ElementHandle } from 'puppeteer-core'
 import { delay } from './utils'
+import { highlightNodeByUid } from './snapshotOperations'
 
 /**
  * 无障碍树节点类型（SerializedAXNode）
@@ -226,5 +227,21 @@ export class SnapshotManager {
     }
 
     return true
+  }
+
+  /**
+   * 高亮页面可点击的项
+   * @param isHighlight 是否高亮
+   */
+  async highlightPage(isHighlight: boolean) {
+    if (this.currentSnapshot) {
+      await this.createTextSnapshot()
+    }
+
+    for (const [id, node] of this.currentSnapshot.idToNode.entries()) {
+      if (node.backendDOMNodeId || node.backendNodeId) {
+        highlightNodeByUid(this, node.id, isHighlight)
+      }
+    }
   }
 }

--- a/packages/next-wxt/entrypoints/sidepanel/utils/snapshotManager.ts
+++ b/packages/next-wxt/entrypoints/sidepanel/utils/snapshotManager.ts
@@ -240,7 +240,7 @@ export class SnapshotManager {
 
     for (const [id, node] of this.currentSnapshot.idToNode.entries()) {
       if (node.backendDOMNodeId || node.backendNodeId) {
-        highlightNodeByUid(this, node.id, isHighlight)
+        await highlightNodeByUid(this, node.id, isHighlight)
       }
     }
   }

--- a/packages/next-wxt/entrypoints/sidepanel/utils/snapshotOperations.ts
+++ b/packages/next-wxt/entrypoints/sidepanel/utils/snapshotOperations.ts
@@ -259,10 +259,7 @@ export async function scrollNodeByUid(
  * @param uid 节点 UID
  * @returns 复制的文本内容
  */
-export async function copyFromNodeByUid(
-  manager: SnapshotManager,
-  uid: string
-): Promise<string> {
+export async function copyFromNodeByUid(manager: SnapshotManager, uid: string): Promise<string> {
   const page = manager.getPage()
   if (!page) {
     throw new Error('页面未连接')
@@ -300,11 +297,7 @@ export async function copyFromNodeByUid(
  * @param uid 节点 UID
  * @param text 要粘贴的文本
  */
-export async function pasteIntoNodeByUid(
-  manager: SnapshotManager,
-  uid: string,
-  text: string
-): Promise<void> {
+export async function pasteIntoNodeByUid(manager: SnapshotManager, uid: string, text: string): Promise<void> {
   const page = manager.getPage()
   if (!page) {
     throw new Error('页面未连接')
@@ -326,7 +319,7 @@ export async function pasteIntoNodeByUid(
 
       // 使用 Locator API
       const locator = (handle as any).asLocator()
-      
+
       // 先点击以聚焦
       await locator.click()
       await delay(100)
@@ -341,6 +334,40 @@ export async function pasteIntoNodeByUid(
       // 输入文本（模拟粘贴）
       await locator.fill(text)
     })
+  } finally {
+    // 确保清理资源
+    if (handle && typeof (handle as any).dispose === 'function') {
+      await (handle as any).dispose()
+    }
+  }
+}
+/**
+ * 通过 UID 高亮节点
+ * @param manager 快照管理器
+ * @param uid 节点 UID
+ */
+export async function highlightNodeByUid(manager: SnapshotManager, uid: string, isHighlight: boolean): Promise<void> {
+  const page = manager.getPage()
+  if (!page) {
+    throw new Error('页面未连接')
+  }
+
+  // 获取 ElementHandle
+  const handle = await manager.getElementHandleByUid(uid)
+  if (!handle) {
+    throw new Error(`无法获取元素句柄，UID: ${uid}`)
+  }
+
+  try {
+    if (isHighlight) {
+      await handle.evaluate((el: Element) => {
+        el.style.outline = '2px solid #f2e5f3'
+      })
+    } else {
+      await handle.evaluate((el: Element) => {
+        el.style.outline = 'none'
+      })
+    }
   } finally {
     // 确保清理资源
     if (handle && typeof (handle as any).dispose === 'function') {


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)

1. 查询无障碍信息时，为可点击元素添加边框
2. 遗留添加光标的功能，-----------------  一添加光标移动，无障碍变化，click动作就失效了，且无法保存住页面的el， 待解决。

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/next-sdk/blob/dev/CONTRIBUTING.md#pull-request-specification)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation-related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Page highlights are now automatically cleared when a chat stream completes, returning the UI to normal view after interactions.
  * Visual highlighting of page elements is added during accessibility snapshot operations to give clearer context about scoped elements.
  * Extra tools (tab open/switch actions) now remove page highlighting before performing their actions to avoid leftover highlights interfering with workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->