### PR TITLE
feat: Support plugin name and description configuration in mcp-servers

### DIFF
--- a/docs/guide/tiny-robot-remoter.md
+++ b/docs/guide/tiny-robot-remoter.md
@@ -56,7 +56,7 @@ import { TinyRemoter } from '@opentiny/next-remoter'
 - `genUiAble` 双向绑定是否启用生成式 UI 的渲染，默认值为：false。输入框旁的「生成式 UI 开关」是否显示由**当前模型配置**决定：仅当配置中同时包含 `baseURL` 和 `genuiUrl` 时才会显示该开关
 - `genUiComponents` 生成式 UI 内置了一批组件，如果需要引入新组件，需要通过这里导入。参考示例：`shallowReactive({ TinyUser, TinyAlert })`
 - `customMarketMcpServers` 追加自定义 MCP 市场服务列表（`PluginInfo[]`），传入后会与组件内置的 `DEFAULT_SERVERS` 合并，用于扩展市场内容。**一般对应后台的 MCP 服务，可常驻存在。**
-- `mcpServers` 预置 MCP 服务器配置（业界格式 `Record<string, McpServerConfig>`）。键为服务器名称，值为单台服务器配置；组件初始化时会自动加载并出现在「已添加MCP服务」中。**一般对应前端的 MCP 服务，页面关闭后即不存在。** 配置说明见 [预置 MCP 服务器（mcpServers）](#预置-mcp-服务器mcpservers)
+- `mcpServers` 预置 MCP 服务器配置（业界格式 `Record<string, McpServerConfig>`）。键为服务器名称，值为单台服务器配置；组件初始化时会自动加载并出现在「已添加MCP服务」中。**一般对应前端的 MCP 服务，页面关闭后即不存在。** 支持配置自定义 `name`（插件显示名称）和 `description`（插件功能描述），配置说明见 [预置 MCP 服务器（mcpServers）](#预置-mcp-服务器mcpservers)
 - `pageToolsOnDemand` 已移除（破坏性变更），请勿继续传该属性
 - `skills` 设置技能的配置对象（`Record<string, string>` 类型）。通常配合 Vite 的 `import.meta.glob` 导入标准 `SKILL.md` 文件。AI 助手会自动识别用户意图并调用相应的技能，无需手动触发。
 - `layout-mode` 布局模式，支持所有 CSS position 属性值：`'static' | 'relative' | 'absolute' | 'fixed' | 'sticky'`，默认值为 `'fixed'`。用于控制组件的定位方式
@@ -492,6 +492,8 @@ const mcpServers = {
   'my-app-mcp-server': {
     type: 'streamableHttp',
     url: 'https://agent.opentiny.design/api/v1/webmcp-trial/mcp?sessionId=xxx',
+    name: '我的自定义助手', // 可选：插件在面板中显示的名称
+    description: '这是一个预置的专业助手服务', // 可选：插件的描述信息
     // 支持配置自定义 Header
     headers: {
       'X-Project-Id': 'project-456'
@@ -499,12 +501,13 @@ const mcpServers = {
   },
   'local-mcp-server': {
     type: 'local',
-    transport: clientTransport
+    transport: clientTransport,
+    name: '本地专用工具' // 可选
   }
 }
 ```
 
-`McpServerConfig` 支持以下类型（与 next-sdk 一致）：
+`McpServerConfig` 支持以下类型（与 next-sdk 一致），所有类型均支持可选的 `name` (string) 和 `description` (string) 字段：
 
 - `type: 'streamableHttp'` 或 `type: 'sse'`：需提供 `url`，可选 `useAISdkClient` 和 `headers`
 - `type: 'extension'`：需提供 `url`、`sessionId`，可选 `useAISdkClient` 和 `headers`
@@ -519,7 +522,9 @@ const mcpServers = {
   // 接入浏览器原生 WebMCP 能力（需浏览器支持或通过 SDK 模拟）
   'builtin-mcp': {
     type: 'builtin',
-    client: nav.modelContextTesting // 指向原生测试接口
+    client: nav.modelContextTesting, // 指向原生测试接口
+    name: '浏览器内置工具', // 自定义插件名称
+    description: '通过原生测试接口暴露的工具集' // 自定义描述
   }
 }
 ```

--- a/packages/doc-ai/src/App.vue
+++ b/packages/doc-ai/src/App.vue
@@ -231,7 +231,9 @@ const nav = navigator as Navigator & { modelContextTesting?: object }
 const mcpServers: Record<string, McpServerConfig> = {
   'mcp-server-builtin-webmcp': {
     type: 'builtin' as const,
-    client: nav.modelContextTesting
+    client: nav.modelContextTesting,
+    name: '浏览器内置工具',
+    description: '通过 navigator.modelContextTesting 暴露的浏览器原生 MCP 工具'
   }
 }
 

--- a/packages/next-remoter/src/composable/usePlugin.ts
+++ b/packages/next-remoter/src/composable/usePlugin.ts
@@ -201,27 +201,33 @@ export function usePlugin(
    */
   const loadMcpServerToPlugin = async (serverName: string, mcpServer: McpServerConfig) => {
     // 解析 URL 和 sessionId
-    let pluginName: string
-    let description: string
+    let pluginName = mcpServer.name
+    let description = mcpServer.description
 
-    if ('type' in mcpServer && mcpServer.type === 'local') {
-      pluginName = '本地工具'
-      description = '本地工具列表'
-    } else if ('type' in mcpServer && mcpServer.type === 'builtin') {
-      // 浏览器内置 WebMCP（Chrome 146+）：没有 url，使用固定名称标识
-      pluginName = '浏览器内置工具'
-      description = '通过 navigator.modelContextTesting 暴露的浏览器原生 MCP 工具'
-    } else {
-      const url = new URL(mcpServer.url)
-      pluginName = url.origin
-      description = url.searchParams.get('sessionId') || ('sessionId' in mcpServer ? mcpServer.sessionId : '') || ''
+    if (!pluginName || !description) {
+      if ('type' in mcpServer && mcpServer.type === 'local') {
+        pluginName = pluginName || '本地工具'
+        description = description || '本地工具列表'
+      } else if ('type' in mcpServer && mcpServer.type === 'builtin') {
+        // 浏览器内置 WebMCP（Chrome 146+）：没有 url，使用固定名称标识
+        pluginName = pluginName || '浏览器内置工具'
+        description = description || '通过 navigator.modelContextTesting 暴露的浏览器原生 MCP 工具'
+      } else if ('url' in mcpServer) {
+        const url = new URL(mcpServer.url)
+        pluginName = pluginName || url.origin
+        description =
+          description ||
+          url.searchParams.get('sessionId') ||
+          ('sessionId' in mcpServer ? mcpServer.sessionId : '') ||
+          ''
+      }
     }
 
     // 使用统一的添加核心函数
     await addPluginCore({
       pluginId: serverName,
-      name: pluginName,
-      description: description,
+      name: pluginName || '',
+      description: description || '',
       mcpServer
     })
   }

--- a/packages/next-remoter/src/composable/usePlugin.ts
+++ b/packages/next-remoter/src/composable/usePlugin.ts
@@ -213,13 +213,19 @@ export function usePlugin(
         pluginName = pluginName || '浏览器内置工具'
         description = description || '通过 navigator.modelContextTesting 暴露的浏览器原生 MCP 工具'
       } else if ('url' in mcpServer) {
-        const url = new URL(mcpServer.url)
-        pluginName = pluginName || url.origin
-        description =
-          description ||
-          url.searchParams.get('sessionId') ||
-          ('sessionId' in mcpServer ? mcpServer.sessionId : '') ||
-          ''
+        try {
+          const url = new URL(mcpServer.url)
+          pluginName = pluginName || url.origin
+          description =
+            description ||
+            url.searchParams.get('sessionId') ||
+            ('sessionId' in mcpServer ? mcpServer.sessionId : '') ||
+            ''
+        } catch (e) {
+          console.error('[usePlugin] Failed to parse MCP server URL:', mcpServer.url, e)
+          pluginName = pluginName || '未知插件'
+          description = description || ''
+        }
       }
     }
 
@@ -334,12 +340,18 @@ export function usePlugin(
     } as const
 
     // 解析URL获取origin作为插件名称
-    const url = new URL(`${agentRoot}mcp?sessionId=${sessionId}`)
+    let name = '未知插件'
+    try {
+      const url = new URL(`${agentRoot}mcp?sessionId=${sessionId}`)
+      name = url.origin
+    } catch (e) {
+      console.error('[usePlugin] Failed to parse scan URL:', e)
+    }
 
     // 使用统一的添加核心函数
     return await addPluginCore({
       pluginId: `plugin-${sessionId}`,
-      name: url.origin,
+      name,
       description: sessionId,
       mcpServer
     })

--- a/packages/next-sdk/agent/type.ts
+++ b/packages/next-sdk/agent/type.ts
@@ -46,10 +46,32 @@ export type IAgentModelProviderLlmConfig = LlmFactoryConfig | LlmInstanceConfig
 
 /** Mcp Server的配置对象 */
 export type McpServerConfig =
-  | { type: 'streamableHttp'; url: string; useAISdkClient?: boolean; headers?: Record<string, string> }
-  | { type: 'sse'; url: string; useAISdkClient?: boolean; headers?: Record<string, string> }
-  | { type: 'extension'; url: string; sessionId: string; useAISdkClient?: boolean; headers?: Record<string, string> }
-  | { type: 'local'; transport: MCPTransport; useAISdkClient?: boolean }
+  | {
+      type: 'streamableHttp'
+      url: string
+      useAISdkClient?: boolean
+      headers?: Record<string, string>
+      name?: string
+      description?: string
+    }
+  | {
+      type: 'sse'
+      url: string
+      useAISdkClient?: boolean
+      headers?: Record<string, string>
+      name?: string
+      description?: string
+    }
+  | {
+      type: 'extension'
+      url: string
+      sessionId: string
+      useAISdkClient?: boolean
+      headers?: Record<string, string>
+      name?: string
+      description?: string
+    }
+  | { type: 'local'; transport: MCPTransport; useAISdkClient?: boolean; name?: string; description?: string }
   | {
       /**
        * 浏览器内置 WebMCP 类型。
@@ -59,6 +81,8 @@ export type McpServerConfig =
       type: 'builtin'
       /** 传入 `navigator.modelContextTesting` 对象 */
       client: BuiltinMcpClient
+      name?: string
+      description?: string
     }
 
 /** */


### PR DESCRIPTION
feat: mcp-servers配置项支持配置插件名称和描述
# Pull Request (OpenTiny NEXT-SDKs)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/next-sdk/blob/dev/CONTRIBUTING.md#pull-request-specification)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation-related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP server configurations now support optional `name` and `description` metadata fields, allowing users to customize plugin display names and descriptions.

* **Documentation**
  * Updated guides to demonstrate the new metadata fields with practical examples across different server types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->