### PR TITLE
fix: 修改异步skill的内容不能加载的bug

### DIFF
--- a/packages/next-sdk/index.ts
+++ b/packages/next-sdk/index.ts
@@ -46,7 +46,6 @@ export * from './page-tools/bridge'
 export {
   getSkillOverviews,
   formatSkillsForSystemPrompt,
-  getSkillMdPaths,
   getSkillMdContent,
   getMainSkillPaths,
   getMainSkillPathByName,

--- a/packages/next-sdk/skills/index.ts
+++ b/packages/next-sdk/skills/index.ts
@@ -72,7 +72,7 @@ async function normalizeSkillModuleKeys(
  * 获取所有「主 SKILL.md」的路径（一级子目录下的 SKILL.md）
  * - 对传入的 modules 先做 normalize，兼容任意 import.meta.glob 写法
  */
-export async function getMainSkillPaths(modules: Record<string, string>): Promise<string[]> {
+export async function getMainSkillPaths(modules: Record<string, string | (() => Promise<string>)>): Promise<string[]> {
   const normalized = await normalizeSkillModuleKeys(modules)
   return Object.keys(normalized).filter((path) => MAIN_SKILL_PATH_REG.test(path))
 }
@@ -81,7 +81,9 @@ export async function getMainSkillPaths(modules: Record<string, string>): Promis
  * 获取所有技能的概况列表（name、description、path），用于 systemPrompt 或列表展示
  * - 内部统一对 modules 做 normalize，避免调用方关心路径细节
  */
-export async function getSkillOverviews(modules: Record<string, string>): Promise<SkillMeta[]> {
+export async function getSkillOverviews(
+  modules: Record<string, string | (() => Promise<string>)>
+): Promise<SkillMeta[]> {
   const normalized = await normalizeSkillModuleKeys(modules)
   const mainPaths = Object.keys(normalized).filter((path) => MAIN_SKILL_PATH_REG.test(path))
   const list: SkillMeta[] = []
@@ -115,7 +117,7 @@ export function formatSkillsForSystemPrompt(skills: SkillMeta[]): string {
  *
  * TODO: 没有地方调用该函数
  */
-export async function getSkillMdPaths(modules: Record<string, string>): Promise<string[]> {
+export async function getSkillMdPaths(modules: Record<string, string | (() => Promise<string>)>): Promise<string[]> {
   const normalized = await normalizeSkillModuleKeys(modules)
   return Object.keys(normalized)
 }
@@ -124,7 +126,10 @@ export async function getSkillMdPaths(modules: Record<string, string>): Promise<
  * 根据相对路径获取某个技能文档的原始内容（支持 .md、.json、.xml 等文本格式）
  * - 自动对 modules 做 normalize，再按 path 查找
  */
-export async function getSkillMdContent(modules: Record<string, string>, path: string): Promise<string | undefined> {
+export async function getSkillMdContent(
+  modules: Record<string, string | (() => Promise<string>)>,
+  path: string
+): Promise<string | undefined> {
   const normalized = await normalizeSkillModuleKeys(modules)
 
   // 1. 尝试原有的严格匹配
@@ -145,7 +150,7 @@ export async function getSkillMdContent(modules: Record<string, string>, path: s
  * - 依赖 getMainSkillPaths，内部已做 normalize
  */
 export async function getMainSkillPathByName(
-  modules: Record<string, string>,
+  modules: Record<string, string | (() => Promise<string>)>,
   name: string
 ): Promise<string | undefined> {
   const normalizedModules = await normalizeSkillModuleKeys(modules)
@@ -196,19 +201,23 @@ const SKILL_INPUT_SCHEMA = z.object({
 })
 
 let isNormalizeSkillModuleKeys = false
-let normalizeSkillModuleKeysResult
+let normalizeSkillModuleKeysResult: Record<string, string>
 /**
  * 根据 skillMdModules 创建供 AI 调用的工具集
  * - get_skill_content: 按技能名或路径获取完整文档内容，便于大模型自动识别并加载技能
  * remoter 可将返回的 tools 合并进 extraTools 注入 agent
  */
-export function createSkillTools(modules: Record<string, string>): Promise<SkillToolsSet> {
+export function createSkillTools(modules: Record<string, string | (() => Promise<string>)>): SkillToolsSet {
   // @ts-ignore ai package 的 tool() 函数类型推断存在"类型实例化过深"的已知限制，无法正确推断包含复杂 Zod 链的 schema
   const getSkillContent = tool({
     description:
       '根据技能名称或文档路径获取该技能的完整文档内容。如果你想根据相对路径查阅文件，请务必同时提供你当前所在的文件路径 currentPath。',
     inputSchema: SKILL_INPUT_SCHEMA,
-    execute: async (args: { skillName?: string; path?: string; currentPath?: string }): Record<string, unknown> => {
+    execute: async (args: {
+      skillName?: string
+      path?: string
+      currentPath?: string
+    }): Promise<Record<string, unknown>> => {
       if (!isNormalizeSkillModuleKeys) {
         normalizeSkillModuleKeysResult = await normalizeSkillModuleKeys(modules)
         isNormalizeSkillModuleKeys = true

--- a/packages/next-sdk/skills/index.ts
+++ b/packages/next-sdk/skills/index.ts
@@ -112,17 +112,6 @@ export function formatSkillsForSystemPrompt(skills: SkillMeta[]): string {
 }
 
 /**
- * 获取所有已加载的技能文件路径（含主 SKILL.md 与 reference 下的 .md/.json/.xml 等）
- * - 对 modules 做 normalize 后再返回 key 列表
- *
- * TODO: 没有地方调用该函数
- */
-export async function getSkillMdPaths(modules: Record<string, string | (() => Promise<string>)>): Promise<string[]> {
-  const normalized = await normalizeSkillModuleKeys(modules)
-  return Object.keys(normalized)
-}
-
-/**
  * 根据相对路径获取某个技能文档的原始内容（支持 .md、.json、.xml 等文本格式）
  * - 自动对 modules 做 normalize，再按 path 查找
  */

--- a/packages/next-sdk/skills/index.ts
+++ b/packages/next-sdk/skills/index.ts
@@ -200,14 +200,15 @@ const SKILL_INPUT_SCHEMA = z.object({
     )
 })
 
-let isNormalizeSkillModuleKeys = false
-let normalizeSkillModuleKeysResult: Record<string, string>
 /**
  * 根据 skillMdModules 创建供 AI 调用的工具集
  * - get_skill_content: 按技能名或路径获取完整文档内容，便于大模型自动识别并加载技能
  * remoter 可将返回的 tools 合并进 extraTools 注入 agent
  */
 export function createSkillTools(modules: Record<string, string | (() => Promise<string>)>): SkillToolsSet {
+  let isNormalizeSkillModuleKeys = false
+  let normalizeSkillModuleKeysResult: Record<string, string>
+
   // @ts-ignore ai package 的 tool() 函数类型推断存在"类型实例化过深"的已知限制，无法正确推断包含复杂 Zod 链的 schema
   const getSkillContent = tool({
     description:

--- a/packages/next-sdk/skills/index.ts
+++ b/packages/next-sdk/skills/index.ts
@@ -53,14 +53,17 @@ export async function parseSkillFrontMatter(
  * 以便 getSkillMdContent / getMainSkillPathByName 等能正确按 path 查找。
  * 兼容任意引入位置：./skills/xxx、../skills/xxx、src/skills/xxx 等，取最后一个 skills/ 后的部分并加上 ./
  */
-function normalizeSkillModuleKeys(modules: Record<string, string>): Record<string, string> {
+async function normalizeSkillModuleKeys(
+  modules: Record<string, string | (() => Promise<string>)>
+): Promise<Record<string, string>> {
   const result: Record<string, string> = {}
   for (const [key, content] of Object.entries(modules)) {
     const normalizedKey = key.replace(/\\/g, '/')
     const skillsIndex = normalizedKey.lastIndexOf('skills/')
     const relativePath = skillsIndex >= 0 ? normalizedKey.slice(skillsIndex + 7) : normalizedKey
     const standardPath = relativePath.startsWith('./') ? relativePath : `./${relativePath}`
-    result[standardPath] = content
+    const realContent = typeof content === 'string' ? content : await content()
+    result[standardPath] = realContent
   }
   return result
 }
@@ -69,8 +72,8 @@ function normalizeSkillModuleKeys(modules: Record<string, string>): Record<strin
  * 获取所有「主 SKILL.md」的路径（一级子目录下的 SKILL.md）
  * - 对传入的 modules 先做 normalize，兼容任意 import.meta.glob 写法
  */
-export function getMainSkillPaths(modules: Record<string, string>): string[] {
-  const normalized = normalizeSkillModuleKeys(modules)
+export async function getMainSkillPaths(modules: Record<string, string>): Promise<string[]> {
+  const normalized = await normalizeSkillModuleKeys(modules)
   return Object.keys(normalized).filter((path) => MAIN_SKILL_PATH_REG.test(path))
 }
 
@@ -79,7 +82,7 @@ export function getMainSkillPaths(modules: Record<string, string>): string[] {
  * - 内部统一对 modules 做 normalize，避免调用方关心路径细节
  */
 export async function getSkillOverviews(modules: Record<string, string>): Promise<SkillMeta[]> {
-  const normalized = normalizeSkillModuleKeys(modules)
+  const normalized = await normalizeSkillModuleKeys(modules)
   const mainPaths = Object.keys(normalized).filter((path) => MAIN_SKILL_PATH_REG.test(path))
   const list: SkillMeta[] = []
   for (const path of mainPaths) {
@@ -109,9 +112,11 @@ export function formatSkillsForSystemPrompt(skills: SkillMeta[]): string {
 /**
  * 获取所有已加载的技能文件路径（含主 SKILL.md 与 reference 下的 .md/.json/.xml 等）
  * - 对 modules 做 normalize 后再返回 key 列表
+ *
+ * TODO: 没有地方调用该函数
  */
-export function getSkillMdPaths(modules: Record<string, string>): string[] {
-  const normalized = normalizeSkillModuleKeys(modules)
+export async function getSkillMdPaths(modules: Record<string, string>): Promise<string[]> {
+  const normalized = await normalizeSkillModuleKeys(modules)
   return Object.keys(normalized)
 }
 
@@ -119,8 +124,8 @@ export function getSkillMdPaths(modules: Record<string, string>): string[] {
  * 根据相对路径获取某个技能文档的原始内容（支持 .md、.json、.xml 等文本格式）
  * - 自动对 modules 做 normalize，再按 path 查找
  */
-export function getSkillMdContent(modules: Record<string, string>, path: string): string | undefined {
-  const normalized = normalizeSkillModuleKeys(modules)
+export async function getSkillMdContent(modules: Record<string, string>, path: string): Promise<string | undefined> {
+  const normalized = await normalizeSkillModuleKeys(modules)
 
   // 1. 尝试原有的严格匹配
   const exactMatch = normalized[path]
@@ -139,9 +144,12 @@ export function getSkillMdContent(modules: Record<string, string>, path: string)
  * 支持匹配目录名（如 ecommerce）或 SKILL.md 内 frontmatter 定义的 name
  * - 依赖 getMainSkillPaths，内部已做 normalize
  */
-export async function getMainSkillPathByName(modules: Record<string, string>, name: string): string | undefined {
-  const normalizedModules = normalizeSkillModuleKeys(modules)
-  const paths = getMainSkillPaths(normalizedModules)
+export async function getMainSkillPathByName(
+  modules: Record<string, string>,
+  name: string
+): Promise<string | undefined> {
+  const normalizedModules = await normalizeSkillModuleKeys(modules)
+  const paths = await getMainSkillPaths(normalizedModules)
 
   // 1. 先尝试按目录名精确匹配 (兼容老逻辑)
   const dirMatch = paths.find((p) => p.startsWith(`./${name}/SKILL.md`))
@@ -187,20 +195,26 @@ const SKILL_INPUT_SCHEMA = z.object({
     )
 })
 
+let isNormalizeSkillModuleKeys = false
+let normalizeSkillModuleKeysResult
 /**
  * 根据 skillMdModules 创建供 AI 调用的工具集
  * - get_skill_content: 按技能名或路径获取完整文档内容，便于大模型自动识别并加载技能
  * remoter 可将返回的 tools 合并进 extraTools 注入 agent
  */
-export function createSkillTools(modules: Record<string, string>): SkillToolsSet {
-  const normalizedModules = normalizeSkillModuleKeys(modules)
-
+export function createSkillTools(modules: Record<string, string>): Promise<SkillToolsSet> {
   // @ts-ignore ai package 的 tool() 函数类型推断存在"类型实例化过深"的已知限制，无法正确推断包含复杂 Zod 链的 schema
   const getSkillContent = tool({
     description:
       '根据技能名称或文档路径获取该技能的完整文档内容。如果你想根据相对路径查阅文件，请务必同时提供你当前所在的文件路径 currentPath。',
     inputSchema: SKILL_INPUT_SCHEMA,
     execute: async (args: { skillName?: string; path?: string; currentPath?: string }): Record<string, unknown> => {
+      if (!isNormalizeSkillModuleKeys) {
+        normalizeSkillModuleKeysResult = await normalizeSkillModuleKeys(modules)
+        isNormalizeSkillModuleKeys = true
+      }
+
+      const normalizedModules = normalizeSkillModuleKeysResult
       const { skillName, path: pathArg, currentPath: currentPathArg } = args
       let content: string | undefined
       let resolvedPath = ''
@@ -221,7 +235,7 @@ export function createSkillTools(modules: Record<string, string>): SkillToolsSet
         const dummyBase = `http://localhost/${basePathContext}/`
         const url = new URL(pathArg, dummyBase)
         resolvedPath = '.' + url.pathname
-        content = getSkillMdContent(normalizedModules, resolvedPath)
+        content = await getSkillMdContent(normalizedModules, resolvedPath)
 
         // 尝试 2：如果大模型忘了传正确的 currentPath，或者是强行传错，做个智能根目录回退
         if (content === undefined && (pathArg.startsWith('./') || pathArg.startsWith('../')) && currentPathArg) {
@@ -231,7 +245,7 @@ export function createSkillTools(modules: Record<string, string>): SkillToolsSet
             const fallbackDummyBase = `http://localhost/${skillRoot}/`
             const fallbackUrl = new URL(pathArg, fallbackDummyBase)
             const fallbackPath = '.' + fallbackUrl.pathname
-            content = getSkillMdContent(normalizedModules, fallbackPath)
+            content = await getSkillMdContent(normalizedModules, fallbackPath)
             if (content) {
               resolvedPath = fallbackPath
             }
@@ -250,7 +264,7 @@ export function createSkillTools(modules: Record<string, string>): SkillToolsSet
         const mainPath = await getMainSkillPathByName(normalizedModules, skillName)
         if (mainPath) {
           resolvedPath = mainPath
-          content = getSkillMdContent(normalizedModules, mainPath)
+          content = await getSkillMdContent(normalizedModules, mainPath)
         }
       }
 


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)
fix: 修改异步skill的内容不能加载的bug


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/next-sdk/blob/dev/CONTRIBUTING.md#pull-request-specification)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation-related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Skill modules now support lazy async content loading; normalization is deferred until first use and cached.
  * Skill discovery and content retrieval run asynchronously, improving startup time and tool execution responsiveness.
  * A previously exposed helper was removed from the public API (minor breaking change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->