### PR TITLE
fix: 添加 system-overview 的工具

### DIFF
--- a/packages/webmcp-cli-skill/SKILL.md
+++ b/packages/webmcp-cli-skill/SKILL.md
@@ -70,6 +70,12 @@ webmcp-cli state -t <targetId>   # target a specific tab by its real Chrome targ
 
 > `tabid` 是 **真实的 Chrome target ID**（UUID）。配合 `-t` 可指定某个标签页。
 
+`webmcpTools`的值的数组中如果有 `system-overview`的工具，并且在本轮对话中，该域名下没有调用过它，那么一定要立即执行一下 。`system-overview`工具的返回值能指导后续的操作，比如会包含网站的`模块 & 路由 & 页面工具 &使用规范`等等内容。
+
+```bash
+webmcp-cli run system-overview
+```
+
 #### 何时必须调用 state
 
 | 时机                  | 是否必须先 `state` | 说明                                                                                |

--- a/packages/webmcp-cli-skill/SKILL.md
+++ b/packages/webmcp-cli-skill/SKILL.md
@@ -73,7 +73,7 @@ webmcp-cli state -t <targetId>   # target a specific tab by its real Chrome targ
 `webmcpTools`的值的数组中如果有 `system-overview`的工具，并且在本轮对话中，该域名下没有调用过它，那么一定要立即执行一下 。`system-overview`工具的返回值能指导后续的操作，比如会包含网站的`模块 & 路由 & 页面工具 &使用规范`等等内容。
 
 ```bash
-webmcp-cli run system-overview
+webmcp-cli run system-overview '{}'
 ```
 
 #### 何时必须调用 state


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)

没有集成 到 state 命令内部，是考虑state是反复执行，会造成上下文重复。所以改到skill中进行提示。
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/next-sdk/blob/dev/CONTRIBUTING.md#pull-request-specification)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation-related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added CLI guidance: when a system-overview tool is present but not yet invoked during a state operation, run the system-overview command immediately to surface its output for the current session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->