### PR TITLE
fix: 让cli run 命令支持 argsJson可选， 默认值为 {}

### DIFF
--- a/packages/webmcp-cli-skill/SKILL.md
+++ b/packages/webmcp-cli-skill/SKILL.md
@@ -73,7 +73,7 @@ webmcp-cli state -t <targetId>   # target a specific tab by its real Chrome targ
 `webmcpTools`的值的数组中如果有 `system-overview`的工具，并且在本轮对话中，该域名下没有调用过它，那么一定要立即执行一下 。`system-overview`工具的返回值能指导后续的操作，比如会包含网站的`模块 & 路由 & 页面工具 &使用规范`等等内容。
 
 ```bash
-webmcp-cli run system-overview '{}'
+webmcp-cli run system-overview
 ```
 
 #### 何时必须调用 state

--- a/packages/webmcp-cli/src/bin.ts
+++ b/packages/webmcp-cli/src/bin.ts
@@ -53,14 +53,14 @@ program
   })
 
 program
-  .command('run <toolName> <argsJson>')
+  .command('run <toolName> [argsJson]')
   .description('向指定页签调用指定的 WebMCP 工具执行操作')
   .option('-t, --tabid <id>', '指定页签的 ID')
   .action(async (toolName, argsJson, options) => {
     try {
       const result = await runCommand({
         toolName,
-        argsJson,
+        argsJson: argsJson ?? '{}',
         tabid: parseTabId(options.tabid)
       })
       console.log(JSON.stringify(result, null, 2))

--- a/packages/webmcp-cli/src/commands/run.ts
+++ b/packages/webmcp-cli/src/commands/run.ts
@@ -13,11 +13,13 @@ export async function runCommand({
   try {
     const page = await getTargetPage(browser, tabid)
 
-    // 验证一下是否是合法的 JSON，以防用户传入了非法的字符串
-    try {
-      JSON.parse(argsJson)
-    } catch (e: any) {
-      throw new Error(`参数不是有效的 JSON: ${e.message}`)
+    // 无参工具可省略 argsJson（默认为空字符串）；有参时需传入合法 JSON
+    if (argsJson) {
+      try {
+        JSON.parse(argsJson)
+      } catch (e: any) {
+        throw new Error(`参数不是有效的 JSON: ${e.message}`)
+      }
     }
 
     const result = await page.evaluate(async (name, inputString) => {

--- a/packages/webmcp-cli/src/commands/run.ts
+++ b/packages/webmcp-cli/src/commands/run.ts
@@ -13,7 +13,6 @@ export async function runCommand({
   try {
     const page = await getTargetPage(browser, tabid)
 
-    // 无参工具可省略 argsJson（默认为空字符串）；有参时需传入合法 JSON
     if (argsJson) {
       try {
         JSON.parse(argsJson)
@@ -22,26 +21,30 @@ export async function runCommand({
       }
     }
 
-    const result = await page.evaluate(async (name, inputString) => {
-      const mcp = (navigator as any).modelContextTesting || (navigator as any).modelContext
-      
-      if (!mcp || typeof mcp.executeTool !== 'function') {
-        throw new Error('当前页面没有注入 WebMCP 环境 (navigator.modelContextTesting.executeTool 未找到)')
-      }
+    const result = await page.evaluate(
+      async (name, inputString) => {
+        const mcp = (navigator as any).modelContextTesting || (navigator as any).modelContext
 
-      // executeTool 的第二个参数必须是 JSON 字符串
-      let res = await mcp.executeTool(name, inputString)
-      
-      // executeTool 的返回值可能是普通对象，也可能是 JSON 字符串
-      if (typeof res === 'string') {
-        try {
-          res = JSON.parse(res)
-        } catch (e) {
-          // ignore
+        if (!mcp || typeof mcp.executeTool !== 'function') {
+          throw new Error('当前页面没有注入 WebMCP 环境 (navigator.modelContextTesting.executeTool 未找到)')
         }
-      }
-      return res
-    }, toolName, argsJson)
+
+        // executeTool 的第二个参数必须是 JSON 字符串
+        let res = await mcp.executeTool(name, inputString)
+
+        // executeTool 的返回值可能是普通对象，也可能是 JSON 字符串
+        if (typeof res === 'string') {
+          try {
+            res = JSON.parse(res)
+          } catch (e) {
+            // ignore
+          }
+        }
+        return res
+      },
+      toolName,
+      argsJson
+    )
 
     return result
   } finally {


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)
fix: 让cli run 命令支持 argsJson可选， 默认值为 {}
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/next-sdk/blob/dev/CONTRIBUTING.md#pull-request-specification)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation-related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified the command syntax example by removing the unnecessary empty JSON argument.

* **Refactor**
  * Adjusted error handling for cases where the WebMCP environment is not properly configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->