### PR TITLE
fix: 修复searchTree 分支未正确同步底层 a11y-tree 搜集出来的 refMap的问题

### DIFF
--- a/packages/next-sdk/page-tools/a11y-tree.ts
+++ b/packages/next-sdk/page-tools/a11y-tree.ts
@@ -102,6 +102,10 @@ export interface SearchA11yTreeResult {
   totalLines: number
   /** 原始命中行数（去重前） */
   matchCount: number
+  /** 返回搜索时的 ref 映射 */
+  refMap: RefMap
+  /** 返回搜索时的 yaml 状态，用于更新缓存 */
+  yaml: string
 }
 
 // ─── ARIA 隐式角色静态映射表（覆盖页面 95%+ 的常用标签）───────────────────────
@@ -581,7 +585,7 @@ export function searchA11yTree(
   } = options ?? {}
 
   // 复用 buildA11yTree 生成完整树，直接取 lines 数组（不重复构建 DOM 遍历）
-  const { lines } = buildA11yTree(root, blacklist, whitelist, treeOptions)
+  const { lines, refMap, yaml } = buildA11yTree(root, blacklist, whitelist, treeOptions)
 
   const needle = caseInsensitive ? query.toLowerCase() : query
   const totalLines = lines.length
@@ -665,5 +669,7 @@ export function searchA11yTree(
     matches,
     totalLines,
     matchCount: hitIndices.length,
+    refMap,
+    yaml,
   }
 }

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -299,14 +299,18 @@ export function registerPageAgentTool(options?: PageAgentToolOptions) {
           const blacklist = (window.__webmcpcli_interactiveBlacklist ?? []) as Element[]
           const whitelist = (window.__webmcpcli_interactiveWhitelist ?? []) as Element[]
           const exposedAttributes = (window.__webmcpcli_exposedAttributes ?? []) as string[]
-          const { text } = searchA11yTree(args.query, document.body, blacklist, whitelist, {
+          const result = searchA11yTree(args.query, document.body, blacklist, whitelist, {
             contextLines: args.contextLines,
             maxMatches: args.maxMatches,
             exposedAttributes
           })
+          
+          currentRefMap = result.refMap
+          stateCache.update(window.location.href, result.yaml)
+          
           await pageController.hideMask()
           return {
-            content: [{ type: 'text', text }]
+            content: [{ type: 'text', text: result.text }]
           }
         }
       } catch (error) {


### PR DESCRIPTION
问题如我们所料，page-agent-tool.ts 中的 searchTree 分支未正确同步底层 a11y-tree 搜集出来的 refMap：

我修改了 packages/next-sdk/page-tools/a11y-tree.ts，使得在调用 searchA11yTree 也能透传出最新的 refMap 以及 yaml。
随后修改了 packages/next-sdk/page-tools/page-agent-tool.ts。现在调用 searchTree 时，不但会返回匹配的片段，同时还会自动更新当前环境的 currentRefMap 和 stateCache。
# Pull Request (OpenTiny NEXT-SDKs)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/next-sdk/blob/dev/CONTRIBUTING.md#pull-request-specification)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation-related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tree search results so the app can better track and reuse matched items after a search.
  * Search-related state is now preserved more reliably, helping keep navigation and updates aligned with the latest search results.

* **Bug Fixes**
  * Fixed cases where follow-up actions could lose track of searched elements.
  * Improved consistency between displayed search output and the app’s stored page state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->