### PR TITLE
feat: 优化节点树结构，减少嵌套层次，过滤不可见元素

### DIFF
--- a/packages/next-sdk/page-tools/a11y/utils.ts
+++ b/packages/next-sdk/page-tools/a11y/utils.ts
@@ -4,7 +4,7 @@
  * 存放生成无障碍树时的通用工具函数：节点解析、状态获取、角色推断及纯文本兜底等。
  */
 
-import { isFocusable } from 'tabbable'
+import { isFocusable, isTabbable } from 'tabbable'
 import { TAG_ROLE_MAP, INPUT_TYPE_ROLE, DEFAULT_ERROR_SELECTORS, DEFAULT_WARNING_SELECTORS } from './constants'
 
 /**
@@ -181,11 +181,20 @@ export function isHidden(el: Element): boolean {
   try {
     const style = window.getComputedStyle(el as HTMLElement)
     if (style.display === 'none' || style.visibility === 'hidden') return true
+    // opacity:0 是常见的视觉隐藏方式，元素对用户不可见
+    if (style.opacity === '0') return true
+    // 宽或高为 0 且有 overflow 裁剪时，子内容实际不可见（如折叠的侧边栏 width:0 !important）
+    // 若 overflow 为 visible，子内容仍然溢出可见，不能过滤
+    const isClipX = style.overflowX !== 'visible'
+    const isClipY = style.overflowY !== 'visible'
+    if (parseFloat(style.width) === 0 && isClipX) return true
+    if (parseFloat(style.height) === 0 && isClipY) return true
   } catch {
-    // 忽略
+    // 忽略跨域 iframe 等无法访问 style 的场景
   }
   return false
 }
+
 
 /**
  * 收集子孙节点的文本内容，用作无障碍名字的兜底。
@@ -206,19 +215,14 @@ export function collectDescendantText(el: Element): string {
         const role = inferRole(element)
         const isInteractiveTag = ['button', 'a', 'input', 'select', 'textarea', 'li', 'option'].includes(tag)
         const isInteractiveRole = ['button', 'link', 'checkbox', 'radio', 'textbox', 'listitem', 'option', 'combobox', 'listbox'].includes(role)
-        const isTrulyInteractive = isFocusable(element as HTMLElement)
-
-        let isVisuallyClickable = false
+        const isTrulyInteractive = isTabbable(element as HTMLElement)
+        let isCursorPointer = false
         try {
-          const style = window.getComputedStyle(element as HTMLElement)
-          if (style.cursor === 'pointer') {
-            isVisuallyClickable = true
-          }
-        } catch {
-          // 忽略
-        }
-
-        if (isTrulyInteractive || isVisuallyClickable || isInteractiveTag || isInteractiveRole) {
+          isCursorPointer = window.getComputedStyle(element as HTMLElement).cursor === 'pointer'
+        } catch { /* ignore */ }
+        const isMeaningfullyInteractive = isTrulyInteractive && !(role === 'generic' && !isCursorPointer)
+        
+        if (isMeaningfullyInteractive || isInteractiveTag || isInteractiveRole) {
           return
         }
       }

--- a/packages/next-sdk/page-tools/a11y/vnode.ts
+++ b/packages/next-sdk/page-tools/a11y/vnode.ts
@@ -5,7 +5,7 @@
  */
 
 import { computeAccessibleName } from 'dom-accessibility-api'
-import { isFocusable } from 'tabbable'
+import { isFocusable, isTabbable } from 'tabbable'
 import type { VNode, RefMap, A11yTreeOptions } from './types'
 import { isHidden, inferRole, getStateTokens, collectDescendantText, getComposedChildren } from './utils'
 
@@ -29,6 +29,8 @@ export function buildVNode(
   exposedAttributes?: string[],
   errorSelectors?: string | string[],
   warningSelectors?: string | string[],
+  /** 祖先节点是否已是可交互节点（已分配 ref）。为 true 时，纯 CSS 继承的 cursor=pointer 不再额外分配 ref */
+  ancestorIsInteractive = false,
 ): VNode | null {
   if (isHidden(el) || blacklistSet.has(el)) return null
 
@@ -36,7 +38,7 @@ export function buildVNode(
   const tokens = getStateTokens(el, exposedAttributes, errorSelectors, warningSelectors)
   
   let name = computeAccessibleName(el as HTMLElement)
-  const isTrulyInteractive = isFocusable(el as HTMLElement)
+  const isTrulyInteractive = isTabbable(el as HTMLElement)
   const isVisuallyClickable = tokens.includes('cursor=pointer')
   // 包含白名单属性的节点也视为白名单节点（确保不被剪枝并分配 ref 操作索引）
   const isWhitelisted = whitelistSet.has(el) || (exposedAttributes?.some(attr => el.hasAttribute(attr)) ?? false)
@@ -73,8 +75,26 @@ export function buildVNode(
   }
 
   // generic 无 name 时，即使有 cursor=pointer 也不分配 ref：
-  // cursor 通常是 CSS 继承传播的，这类 div 本身无法被有意义地操作
-  const interactive = isTrulyInteractive || isWhitelisted || isLabelFor || (isVisuallyClickable && (role !== 'generic' || name !== ''))
+  // cursor 通常是 CSS 继承传播的，这类 div 本身无法被有意义地操作。
+  // 此外，当祖先节点已是可交互节点时，子节点仅凭 isVisuallyClickable（CSS 继承）
+  // 不再额外分配 ref，避免父节点 cursor:pointer 传染给所有子孙导致高亮泛滥。
+  //
+  // 例外：<a>/<button>/<input> 等语义性交互标签，无论祖先是否已有 ref，
+  // 始终强制分配 ref，因为它们在 HTML 语义上就是独立的操作单元。
+  const isSemanticInteractiveTag = ['a', 'button', 'input', 'select', 'textarea'].includes(
+    el.tagName.toLowerCase()
+  )
+
+  // 虽然有些元素有 tabindex="0" (isTrulyInteractive)，但如果它是 generic 且没有 cursor:pointer，
+  // 往往是开发者加的结构化 focus 容器（如 tp-card），而非真正的可交互按钮，我们在此过滤掉它们。
+  const isMeaningfullyInteractive = isTrulyInteractive && !(role === 'generic' && !isVisuallyClickable)
+
+  const interactive =
+    isMeaningfullyInteractive ||
+    isWhitelisted ||
+    isLabelFor ||
+    isSemanticInteractiveTag ||
+    (!ancestorIsInteractive && isVisuallyClickable && (role !== 'generic' || name !== ''))
 
   let ref: number | undefined
   if (interactive) {
@@ -85,7 +105,18 @@ export function buildVNode(
 
   const children: VNode[] = []
   for (const child of getComposedChildren(el)) {
-    const childVNode = buildVNode(child, refCounter, refMap, blacklistSet, whitelistSet, exposedAttributes, errorSelectors, warningSelectors)
+    const childVNode = buildVNode(
+      child,
+      refCounter,
+      refMap,
+      blacklistSet,
+      whitelistSet,
+      exposedAttributes,
+      errorSelectors,
+      warningSelectors,
+      // 将当前节点的交互性向下传递，子节点据此决定是否抑制 cursor=pointer
+      interactive || ancestorIsInteractive,
+    )
     if (childVNode) children.push(childVNode)
   }
 
@@ -99,6 +130,29 @@ export function buildVNode(
 export function hasValue(vnode: VNode): boolean {
   if (vnode.ref !== undefined || vnode.name.trim() !== '') return true
   return vnode.children.some(hasValue)
+}
+
+/**
+ * 检查节点子树中是否存在任何有 ref 的可交互子节点。
+ * 用于判断父节点是否可以安全省略其子节点输出。
+ */
+function hasInteractiveDescendant(vnode: VNode): boolean {
+  return vnode.children.some(c => c.ref !== undefined || hasInteractiveDescendant(c))
+}
+
+/**
+ * 找到子树中恰好唯一一个有 ref 的节点，若有多个则返回 null。
+ * 用于判断是否可将该子节点与父节点合并输出。
+ */
+function findSingleRefDescendant(vnode: VNode): VNode | null {
+  const refs: VNode[] = []
+  const collect = (v: VNode) => {
+    if (v.ref !== undefined) refs.push(v)
+    if (refs.length > 1) return  // 超过一个就提前退出
+    v.children.forEach(collect)
+  }
+  vnode.children.forEach(collect)
+  return refs.length === 1 ? refs[0] : null
 }
 
 /**
@@ -132,7 +186,7 @@ export function serializeVNode(
 ): string[] {
   if (shouldPassThrough(vnode, opts)) {
     // 透明穿透：跳过本节点，子节点保持当前 depth（层级不增加）
-    // 同时过滤掉整棵子树都无价值的空容器，避免输出无意义的嵌套
+    // 同时过滤掉整棵子树都无价値的空容器，避免输出无意义的嵌套
     return vnode.children
       .filter(c => hasValue(c))
       .flatMap(c => serializeVNode(c, depth, opts))
@@ -142,6 +196,29 @@ export function serializeVNode(
   const refStr = vnode.ref !== undefined ? ` #${vnode.ref}` : ''
   const safeTokens = vnode.tokens.map(t => t.replace(/[\r\n]+/g, ' ').replace(/"/g, '\\"'))
   const tokenStr = safeTokens.length > 0 ? ` [${safeTokens.join(' ')}]` : ''
+
+  if (vnode.ref !== undefined) {
+    if (!hasInteractiveDescendant(vnode)) {
+      // 子树无任何 ref 节点 → 直接省略子节点
+      // 父节点的 name 已由 computeAccessibleName 汇总了子树文本，信息不会丢失
+      const safeName = vnode.name ? vnode.name.replace(/[\r\n]+/g, ' ').replace(/"/g, '\\"') : ''
+      const nameStr = safeName ? ` "${safeName}"` : ''
+      return [`${indent}- ${vnode.role}${refStr}${tokenStr}${nameStr}`]
+    }
+
+    // 子树中唯一一个 ref 节点且是无子 ref 的 generic 时，将其 name 提升到父节点，省略子节点输出。
+    // 场景：`listitem #22 [active]` 内部只有 `generic #23 "总览"`，
+    //       点击意义相同时，就展示为一行 `- listitem #22 [active] "总览"`。
+    const singleChild = findSingleRefDescendant(vnode)
+    if (singleChild && singleChild.role === 'generic' && !hasInteractiveDescendant(singleChild)) {
+      const mergedName = (vnode.name.trim() || singleChild.name.trim())
+        .replace(/[\r\n]+/g, ' ')
+        .replace(/"/g, '\\"')
+      const nameStr = mergedName ? ` "${mergedName}"` : ''
+      return [`${indent}- ${vnode.role}${refStr}${tokenStr}${nameStr}`]
+    }
+  }
+
   const safeName = vnode.name ? vnode.name.replace(/[\r\n]+/g, ' ').replace(/"/g, '\\"') : ''
   const nameStr = safeName ? ` "${safeName}"` : ''
   const line = `${indent}- ${vnode.role}${refStr}${tokenStr}${nameStr}`

--- a/packages/next-sdk/page-tools/a11y/vnode.ts
+++ b/packages/next-sdk/page-tools/a11y/vnode.ts
@@ -81,9 +81,10 @@ export function buildVNode(
   //
   // 例外：<a>/<button>/<input> 等语义性交互标签，无论祖先是否已有 ref，
   // 始终强制分配 ref，因为它们在 HTML 语义上就是独立的操作单元。
-  const isSemanticInteractiveTag = ['a', 'button', 'input', 'select', 'textarea'].includes(
-    el.tagName.toLowerCase()
-  )
+  const tagName = el.tagName.toLowerCase()
+  const isSemanticInteractiveTag =
+    (tagName === 'a' && el.hasAttribute('href')) ||
+    (['button', 'input', 'select', 'textarea'].includes(tagName) && !el.hasAttribute('disabled'))
 
   // 虽然有些元素有 tabindex="0" (isTrulyInteractive)，但如果它是 generic 且没有 cursor:pointer，
   // 往往是开发者加的结构化 focus 容器（如 tp-card），而非真正的可交互按钮，我们在此过滤掉它们。

--- a/packages/next-sdk/page-tools/page-agent-highlight/index.ts
+++ b/packages/next-sdk/page-tools/page-agent-highlight/index.ts
@@ -17,7 +17,7 @@ const colors = [
   '#4682B4'
 ]
 // border + label opacity
-const opacity = Math.floor(0.1 * 255)
+const opacity = Math.floor(0.3 * 255)
   .toString(16)
   .padStart(2, '0')
 


### PR DESCRIPTION
Bug A：A11y 元素高亮泛滥与操作索引（ref）过度分配
根因：在很多页面中，父级容器（如卡片、列表项）设置了 cursor: pointer。由于 CSS 的继承特性，其内部的所有子孙 div（generic 节点）也会被计算为拥有 cursor: pointer。旧逻辑据此把所有子节点都误判为“可操作元素”并分配了 ref 索引，导致高亮框层叠泛滥，A11y 树极其臃肿。
为什么要这么改：
在 buildVNode 中引入了 ancestorIsInteractive 参数。当向下构建子树时，如果祖先节点已经是可操作节点（已分配过 ref），其子孙节点即使带有继承的 cursor: pointer 也不再额外分配 ref 索引。
仅有 a、button、input 等在 HTML 语义上本身就是独立操作单元的原生标签才会被强制保留分配。由此有效抑制了高亮的扩散，清除了冗余索引。
Bug B：Tabindex 结构化容器被误判为可操作节点
根因：许多组件的容器为了实现键盘无障碍聚焦（设置了 tabindex="0"），会被 isFocusable 判定为交互节点。但其实它们仅是卡片等结构容器，并没有绑定点击事件（也没有 cursor: pointer 样式），这引入了大量无意义的 generic ref。
为什么要这么改：
用更加严格的 isTabbable 替代 isFocusable。
引入 isMeaningfullyInteractive 判断：若节点为 generic 且没有 cursor: pointer 样式，即使它是 tabbable 也予以排除，只保留真正可交互的项。
A11y 序列化冗余嵌套与 Token 消耗过大
根因：旧逻辑在序列化时对整个 A11y 树做无差别全量递归展开。实际上，许多有 ref 的父级元素（如按钮、链接）其 Accessible Name 已经汇总了子树的文本，继续序列化其子节点属于严重的 Token 浪费。
为什么要这么改：
子树剪枝（hasInteractiveDescendant）：若父节点有 ref 且子树中不再有任何交互式 ref 节点，直接省略整个子树输出。
单一子节点合并（findSingleRefDescendant）：若父节点有 ref 且子树中有且仅有一个无交互子节点的 generic ref 节点（例如列表项中包裹的唯一文字），将其 name 提升与父节点合并成单行输出（例如 - listitem #22 "总览"），消除不必要的嵌套结构。
修改后效果：
<img width="3360" height="1774" alt="image" src="https://github.com/user-attachments/assets/d62488a9-ab14-4f7f-b798-39856652cbae" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility text detection to ignore hidden elements more reliably, including fully transparent items and clipped/zero-sized regions.
  * Updated interactive-element detection to rely on true tabbability and better handle generic roles with pointer cues.
  * Simplified accessibility output by pruning subtrees without additional interactive descendants and compacting common single-descendant cases.
* **Style**
  * Increased page highlight overlay opacity for better visual inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->