### PR TITLE
feat: page agent tool event

### DIFF
--- a/packages/next-sdk/index.ts
+++ b/packages/next-sdk/index.ts
@@ -54,3 +54,7 @@ export * from '@mcp-b/webmcp-polyfill'
 
 export { initializeBuiltinWebMCP } from './page-tools/initialize-builtin-WebMCP'
 export { registerPageAgentTool } from './page-tools/page-agent-tool'
+export {
+  PAGE_AGENT_TOOL_CALL_EVENT,
+  PAGE_AGENT_TOOL_RESULT_EVENT
+} from './page-tools/page-agent-tool-event'

--- a/packages/next-sdk/index.ts
+++ b/packages/next-sdk/index.ts
@@ -54,7 +54,5 @@ export * from '@mcp-b/webmcp-polyfill'
 
 export { initializeBuiltinWebMCP } from './page-tools/initialize-builtin-WebMCP'
 export { registerPageAgentTool } from './page-tools/page-agent-tool'
-export {
-  PAGE_AGENT_TOOL_CALL_EVENT,
-  PAGE_AGENT_TOOL_RESULT_EVENT
-} from './page-tools/page-agent-tool-event'
+export { PAGE_AGENT_TOOL_CALL_EVENT, PAGE_AGENT_TOOL_RESULT_EVENT } from './page-tools/page-agent-tool-event'
+export type { PageAgentToolCallEventDetail, PageAgentToolResultEventDetail } from './page-tools/page-agent-tool-event'

--- a/packages/next-sdk/page-tools/page-agent-tool-event.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool-event.ts
@@ -1,8 +1,10 @@
+import { inputSchema, type PageAgentToolInput, type PageAgentToolRawInput } from './schema'
+
 export const PAGE_AGENT_TOOL_CALL_EVENT = 'page-agent-tool-call'
 export const PAGE_AGENT_TOOL_RESULT_EVENT = 'page-agent-tool-result'
 
 export type PageAgentToolCallEventDetail = {
-  data?: Record<string, unknown>
+  data?: PageAgentToolRawInput
   requestId: string
 }
 
@@ -15,7 +17,7 @@ export type PageAgentToolResultEventDetail = {
   requestId: string
 }
 
-type ExecutePageAgentTool = (data: Record<string, unknown>) => Promise<unknown>
+type ExecutePageAgentTool = (data: PageAgentToolInput) => Promise<unknown>
 
 declare global {
   interface Window {
@@ -46,7 +48,8 @@ export function setupPageAgentToolEventBridge(executePageAgentTool: ExecutePageA
     }
 
     try {
-      const result = await executePageAgentTool(detail.data ?? {})
+      const data = inputSchema.parse(detail.data)
+      const result = await executePageAgentTool(data)
       dispatchPageAgentToolResult({
         requestId,
         data: {

--- a/packages/next-sdk/page-tools/page-agent-tool-event.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool-event.ts
@@ -1,0 +1,73 @@
+export const PAGE_AGENT_TOOL_CALL_EVENT = 'page-agent-tool-call'
+export const PAGE_AGENT_TOOL_RESULT_EVENT = 'page-agent-tool-result'
+
+export type PageAgentToolCallEventDetail = {
+  data?: Record<string, unknown>
+  requestId: string
+}
+
+export type PageAgentToolResultEventDetail = {
+  data: {
+    success: boolean
+    result?: unknown
+    error?: string
+  }
+  requestId: string
+}
+
+type ExecutePageAgentTool = (data: Record<string, unknown>) => Promise<unknown>
+
+declare global {
+  interface Window {
+    __nextSdkPageAgentToolEventCleanup?: () => void
+  }
+}
+
+function dispatchPageAgentToolResult(detail: PageAgentToolResultEventDetail) {
+  window.dispatchEvent(new CustomEvent(PAGE_AGENT_TOOL_RESULT_EVENT, { detail }))
+}
+
+export function setupPageAgentToolEventBridge(executePageAgentTool: ExecutePageAgentTool) {
+  window.__nextSdkPageAgentToolEventCleanup?.()
+
+  const handleToolCall = async (event: Event) => {
+    const detail = (event as CustomEvent<PageAgentToolCallEventDetail>).detail
+    const requestId = detail?.requestId
+
+    if (!requestId) {
+      dispatchPageAgentToolResult({
+        requestId: '',
+        data: {
+          success: false,
+          error: '缺少 requestId'
+        }
+      })
+      return
+    }
+
+    try {
+      const result = await executePageAgentTool(detail.data ?? {})
+      dispatchPageAgentToolResult({
+        requestId,
+        data: {
+          success: true,
+          result
+        }
+      })
+    } catch (error) {
+      dispatchPageAgentToolResult({
+        requestId,
+        data: {
+          success: false,
+          error: error instanceof Error ? error.message : String(error)
+        }
+      })
+    }
+  }
+
+  window.addEventListener(PAGE_AGENT_TOOL_CALL_EVENT, handleToolCall)
+  window.__nextSdkPageAgentToolEventCleanup = () => {
+    window.removeEventListener(PAGE_AGENT_TOOL_CALL_EVENT, handleToolCall)
+    window.__nextSdkPageAgentToolEventCleanup = undefined
+  }
+}

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -166,20 +166,24 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}) {
       }
     } catch (error) {
       await pageController.hideMask()
-      return { content: [{ type: 'text', text: `异常: ${String(error)}` }] }
+      throw error
     }
   }
 
-  setupPageAgentToolEventBridge(executePageAgentTool)
-
-    // ─── 工具注册（名称与 inputSchema 与原版完全一致）────────────────────────
-    ; (document as any).modelContext.registerTool({
-      name: 'page-agent-tool',
-      description: pageAgentPrompt,
-      // @ts-ignore
-      inputSchema: zodToJsonSchema(inputSchema) as any,
-      async execute(args: PageAgentToolInput) {
+  // ─── 工具注册（名称与 inputSchema 与原版完全一致）────────────────────────
+  ; (document as any).modelContext.registerTool({
+    name: 'page-agent-tool',
+    description: pageAgentPrompt,
+    // @ts-ignore
+    inputSchema: zodToJsonSchema(inputSchema) as any,
+    async execute(args: PageAgentToolInput) {
+      try {
         return executePageAgentTool(args)
+      } catch (error) {
+        return { content: [{ type: 'text' as const, text: `异常: ${String(error)}` }] }
       }
-    })
+    }
+  })
+
+  setupPageAgentToolEventBridge(executePageAgentTool)
 }

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -6,6 +6,7 @@ import { buildA11yTree, type RefMap } from './a11y-tree'
 import { PageStateCache } from './page-state-cache'
 import { SimulatorMask } from './page-agent-mask/SimulatorMask'
 import { highlight, unhighlight, globalRemoveListener } from './page-agent-highlight'
+import { setupPageAgentToolEventBridge } from './page-agent-tool-event'
 
 import { DEFAULT_ERROR_SELECTORS, DEFAULT_DIALOG_SELECTORS, type PageAgentToolOptions } from './constants'
 import { inputSchema, type PageAgentToolInput } from './schema'
@@ -137,39 +138,48 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}) {
     errContent
   }
 
-  // ─── 工具注册（名称与 inputSchema 与原版完全一致）────────────────────────
-  ;(document as any).modelContext.registerTool({
-    name: 'page-agent-tool',
-    description: pageAgentPrompt,
-    // @ts-ignore
-    inputSchema: zodToJsonSchema(inputSchema) as any,
-    async execute(args: PageAgentToolInput) {
+  async function executePageAgentTool(args: PageAgentToolInput) {
+    const isReadOnlyAction = ['browserState', 'searchTree'].includes(args.action)
+    if (!isReadOnlyAction) {
       await pageController.showMask()
-      try {
-        switch (args.action) {
-          case 'browserState':
-            return await handleBrowserState(args, actionContext)
-          case 'click':
-            return await handleClick(args, actionContext)
-          case 'fill':
-            return await handleFill(args, actionContext)
-          case 'select':
-            return await handleSelect(args, actionContext)
-          case 'scroll':
-            return await handleScroll(args, actionContext)
-          case 'executeJavascript':
-            return await handleExecuteJavascript(args, actionContext)
-          case 'searchTree':
-            return await handleSearchTree(args, actionContext)
-          default:
-            await pageController.hideMask()
-            // @ts-ignore
-            return { content: [{ type: 'text', text: `未知操作: ${args.action}` }] }
-        }
-      } catch (error) {
-        await pageController.hideMask()
-        return { content: [{ type: 'text', text: `异常: ${String(error)}` }] }
-      }
     }
-  })
+    try {
+      switch (args.action) {
+        case 'browserState':
+          return await handleBrowserState(args, actionContext)
+        case 'click':
+          return await handleClick(args, actionContext)
+        case 'fill':
+          return await handleFill(args, actionContext)
+        case 'select':
+          return await handleSelect(args, actionContext)
+        case 'scroll':
+          return await handleScroll(args, actionContext)
+        case 'executeJavascript':
+          return await handleExecuteJavascript(args, actionContext)
+        case 'searchTree':
+          return await handleSearchTree(args, actionContext)
+        default:
+          await pageController.hideMask()
+          // @ts-ignore
+          return { content: [{ type: 'text', text: `未知操作: ${args.action}` }] }
+      }
+    } catch (error) {
+      await pageController.hideMask()
+      return { content: [{ type: 'text', text: `异常: ${String(error)}` }] }
+    }
+  }
+
+  setupPageAgentToolEventBridge(executePageAgentTool)
+
+    // ─── 工具注册（名称与 inputSchema 与原版完全一致）────────────────────────
+    ; (document as any).modelContext.registerTool({
+      name: 'page-agent-tool',
+      description: pageAgentPrompt,
+      // @ts-ignore
+      inputSchema: zodToJsonSchema(inputSchema) as any,
+      async execute(args: PageAgentToolInput) {
+        return executePageAgentTool(args)
+      }
+    })
 }

--- a/packages/next-sdk/page-tools/schema.ts
+++ b/packages/next-sdk/page-tools/schema.ts
@@ -49,3 +49,4 @@ export const inputSchema = z.object({
 })
 
 export type PageAgentToolInput = z.infer<typeof inputSchema>
+export type PageAgentToolRawInput = z.input<typeof inputSchema>

--- a/packages/next-sdk/runtime.ts
+++ b/packages/next-sdk/runtime.ts
@@ -5,6 +5,12 @@ if (typeof window !== 'undefined') {
   ;(window as any).initializeBuiltinWebMCP = initializeBuiltinWebMCP
   ;(window as any).registerPageAgentTool = registerPageAgentTool
 
+  // 之前版本存在WebMCP.registerPageAgentTool, 当前先临时兼容，后续再移除
+  if (!(window as any).WebMCP) {
+    ;(window as any).WebMCP = {}
+  }
+  ;(window as any).WebMCP.registerPageAgentTool = registerPageAgentTool
+
   // 作为 IIFE 注入到页面 MAIN world 时自动注册 page-agent-tool
   // 避免 content script 需要额外触发（会被 CSP 内联 script 限制拦截）
   registerPageAgentTool()


### PR DESCRIPTION
## 变更内容

- 为 `page-agent-tool` 增加自定义事件
- 只读工具调用时不显示mask
- 添加WebMCP.registerPageAgentTool，临时兼容

## 变更原因

页面外部调用方需要通过事件触发 `page-agent-tool`，同时事件桥接逻辑需要与页面工具的具体执行逻辑解耦，降低原文件的职责和后续维护成本。

## 影响

现有 `registerPageAgentTool` 调用方式不变。调用方可以派发 `page-agent-tool-call` 事件，并通过 `page-agent-tool-result` 获取对应请求的执行结果。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a page-agent tool event bridge for triggering tool actions and receiving correlated results.
  * Exposed event identifiers and supporting types through the Next SDK.
  * Added automatic success and error responses for page-agent tool execution.

* **Bug Fixes**
  * Improved loading-mask handling for read-only, unknown, and failed operations.
  * Added cleanup support to prevent duplicate event listeners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->