### PR TITLE
fix: return browser state on page tool failures

### DIFF
--- a/packages/next-sdk/page-tools/context.ts
+++ b/packages/next-sdk/page-tools/context.ts
@@ -2,12 +2,49 @@ import type { PageController } from '@page-agent/page-controller'
 import type { PageStateCache } from './page-state-cache'
 import type { RefMap } from './a11y-tree'
 
+export type PageAgentToolContentResult = {
+  content: Array<{ type: 'text'; text: string }>
+}
+
+export type PageAgentToolErrorResult = PageAgentToolContentResult & {
+  isError: true
+  error: string
+}
+
+export async function createActionErrorResult(
+  message: string,
+  buildBrowserStateResponse: ActionContext['buildBrowserStateResponse']
+): Promise<PageAgentToolErrorResult> {
+  try {
+    const browserState = await buildBrowserStateResponse('full')
+    return {
+      isError: true,
+      error: message,
+      content: [{ type: 'text', text: `${message}\n\n${browserState.content[0].text}` }]
+    }
+  } catch (error) {
+    return {
+      isError: true,
+      error: message,
+      content: [
+        {
+          type: 'text',
+          text: `${message}\n\n获取最新浏览器状态失败: ${error instanceof Error ? error.message : String(error)}`
+        }
+      ]
+    }
+  }
+}
+
 export interface ActionContext {
   pageController: PageController
   stateCache: PageStateCache
   getRefMap: () => RefMap
   setRefMap: (map: RefMap) => void
-  buildBrowserStateResponse: (mode?: 'full' | 'diff' | 'both') => Promise<{ content: Array<{ type: 'text'; text: string }> }>
+  buildBrowserStateResponse: (
+    mode?: 'full' | 'diff' | 'both'
+  ) => Promise<{ content: Array<{ type: 'text'; text: string }> }>
   refreshOnStaleRef: (action: string, index: number) => Promise<{ content: Array<{ type: 'text'; text: string }> }>
   errContent: (msg: string) => Promise<{ content: Array<{ type: 'text'; text: string }> }>
+  actionError: (msg: string) => Promise<PageAgentToolErrorResult>
 }

--- a/packages/next-sdk/page-tools/handlers/click.ts
+++ b/packages/next-sdk/page-tools/handlers/click.ts
@@ -4,9 +4,13 @@ import type { ActionContext } from '../context'
 
 export async function handleClick(args: any, ctx: ActionContext) {
   const mode = args.responseMode ?? 'diff'
-  if (args.index === undefined) return ctx.errContent('点击结果: 缺少元素索引')
+  if (args.index === undefined) return ctx.actionError('点击结果: 缺少元素索引')
   const el = ctx.getRefMap().get(args.index)
-  if (!el) return ctx.refreshOnStaleRef('点击', args.index)
+  if (!el) {
+    return ctx.actionError(
+      `点击失败: ref 索引 ${args.index} 已失效（页面可能已刷新），已自动重新加载页面状态，请使用新的 ref 索引重试。`
+    )
+  }
 
   // 若 ref 指向 shadow host，解析其内部真正的可点击元素
   let targetEl = el as HTMLElement

--- a/packages/next-sdk/page-tools/handlers/fill.ts
+++ b/packages/next-sdk/page-tools/handlers/fill.ts
@@ -4,15 +4,20 @@ import type { ActionContext } from '../context'
 
 export async function handleFill(args: any, ctx: ActionContext) {
   const mode = args.responseMode ?? 'diff'
-  if (args.index === undefined || typeof args.text !== 'string') return ctx.errContent('填写结果: 缺少元素索引或文本内容')
+  if (args.index === undefined || typeof args.text !== 'string')
+    return ctx.actionError('填写结果: 缺少元素索引或文本内容')
   const el = ctx.getRefMap().get(args.index)
-  if (!el) return ctx.refreshOnStaleRef('填写', args.index)
+  if (!el) {
+    return ctx.actionError(
+      `填写失败: ref 索引 ${args.index} 已失效（页面可能已刷新），已自动重新加载页面状态，请使用新的 ref 索引重试。`
+    )
+  }
 
   let targetEl = el
   if (!(targetEl instanceof HTMLInputElement) && !(targetEl instanceof HTMLTextAreaElement)) {
     // querySelector 不穿透 shadow boundary，对 shadow host 补查其 shadowRoot
-    const innerInput = el.querySelector('input, textarea')
-      ?? (el.shadowRoot?.querySelector('input, textarea') as HTMLElement | null)
+    const innerInput =
+      el.querySelector('input, textarea') ?? (el.shadowRoot?.querySelector('input, textarea') as HTMLElement | null)
     if (innerInput) {
       targetEl = innerInput as HTMLElement
     }
@@ -46,7 +51,7 @@ export async function handleFill(args: any, ctx: ActionContext) {
       }
     }
     if (!fillSuccess) {
-      return ctx.errContent(`填写结果: 无法填写元素 ${args.index}，元素不是 input、textarea 或 contenteditable`)
+      return ctx.actionError(`填写结果: 无法填写元素 ${args.index}，元素不是 input、textarea 或 contenteditable`)
     }
     // shadow DOM 内元素：inputTextElement 派发的合成事件 composed:false，
     // 补发 composed:true 事件确保事件委托框架（如 React）能收到

--- a/packages/next-sdk/page-tools/handlers/select.ts
+++ b/packages/next-sdk/page-tools/handlers/select.ts
@@ -4,23 +4,28 @@ import type { ActionContext } from '../context'
 
 export async function handleSelect(args: any, ctx: ActionContext) {
   const mode = args.responseMode ?? 'diff'
-  if (args.index === undefined || typeof args.text !== 'string') return ctx.errContent('选择结果: 缺少元素索引或文本内容')
+  if (args.index === undefined || typeof args.text !== 'string')
+    return ctx.actionError('选择结果: 缺少元素索引或文本内容')
   let el = ctx.getRefMap().get(args.index) as HTMLSelectElement | HTMLElement | undefined
-  if (!el) return ctx.refreshOnStaleRef('选择', args.index)
+  if (!el) {
+    return ctx.actionError(
+      `选择失败: ref 索引 ${args.index} 已失效（页面可能已刷新），已自动重新加载页面状态，请使用新的 ref 索引重试。`
+    )
+  }
   // 若 ref 指向 shadow host，解析其内部真正的 <select>（与 fill 一致）
   let targetSelect: HTMLSelectElement | null = null
   if (el instanceof HTMLSelectElement) {
     targetSelect = el
   } else {
-    const innerSelect = el.querySelector('select')
-      ?? (el.shadowRoot?.querySelector('select') as HTMLSelectElement | null)
+    const innerSelect =
+      el.querySelector('select') ?? (el.shadowRoot?.querySelector('select') as HTMLSelectElement | null)
     if (innerSelect) {
       targetSelect = innerSelect
     }
   }
 
   if (!targetSelect) {
-    return ctx.errContent(`选择结果: 无法选择元素 ${args.index}，未找到对应的 <select> 元素`)
+    return ctx.actionError(`选择结果: 无法选择元素 ${args.index}，未找到对应的 <select> 元素`)
   }
 
   await selectOptionElement(targetSelect, args.text)

--- a/packages/next-sdk/page-tools/page-agent-tool-event.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool-event.ts
@@ -19,6 +19,17 @@ export type PageAgentToolResultEventDetail = {
 
 type ExecutePageAgentTool = (data: PageAgentToolInput) => Promise<unknown>
 
+function isPageAgentToolErrorResult(result: unknown): result is { isError: true; error: string } {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    'isError' in result &&
+    result.isError === true &&
+    'error' in result &&
+    typeof result.error === 'string'
+  )
+}
+
 declare global {
   interface Window {
     __nextSdkPageAgentToolEventCleanup?: () => void
@@ -50,6 +61,17 @@ export function setupPageAgentToolEventBridge(executePageAgentTool: ExecutePageA
     try {
       const data = inputSchema.parse(detail.data)
       const result = await executePageAgentTool(data)
+      if (isPageAgentToolErrorResult(result)) {
+        dispatchPageAgentToolResult({
+          requestId,
+          data: {
+            success: false,
+            error: result.error,
+            result
+          }
+        })
+        return
+      }
       dispatchPageAgentToolResult({
         requestId,
         data: {

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -10,7 +10,7 @@ import { setupPageAgentToolEventBridge } from './page-agent-tool-event'
 
 import { DEFAULT_ERROR_SELECTORS, DEFAULT_DIALOG_SELECTORS, type PageAgentToolOptions } from './constants'
 import { inputSchema, type PageAgentToolInput } from './schema'
-import type { ActionContext } from './context'
+import { createActionErrorResult, type ActionContext } from './context'
 import { detectPageDialog, detectValidationErrors } from './utils/dom'
 
 import { handleBrowserState } from './handlers/browserState'
@@ -58,6 +58,12 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}) {
   async function errContent(msg: string) {
     await pageController.hideMask()
     return { content: [{ type: 'text' as const, text: msg }] }
+  }
+
+  async function actionError(msg: string) {
+    const result = await createActionErrorResult(msg, buildBrowserStateResponse)
+    await pageController.hideMask()
+    return result
   }
 
   // AI 使用过期 ref 时，自动重建 A11y 树并返回全量状态，
@@ -135,7 +141,8 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}) {
     },
     buildBrowserStateResponse,
     refreshOnStaleRef,
-    errContent
+    errContent,
+    actionError
   }
 
   async function executePageAgentTool(args: PageAgentToolInput) {
@@ -165,13 +172,23 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}) {
           return { content: [{ type: 'text', text: `未知操作: ${args.action}` }] }
       }
     } catch (error) {
+      const actionNames = {
+        click: '点击',
+        fill: '填写',
+        select: '选择'
+      } as const
+      if (args.action in actionNames) {
+        return actionError(
+          `${actionNames[args.action as keyof typeof actionNames]}执行异常: ${error instanceof Error ? error.message : String(error)}`
+        )
+      }
       await pageController.hideMask()
       throw error
     }
   }
 
   // ─── 工具注册（名称与 inputSchema 与原版完全一致）────────────────────────
-  ; (document as any).modelContext.registerTool({
+  ;(document as any).modelContext.registerTool({
     name: 'page-agent-tool',
     description: pageAgentPrompt,
     // @ts-ignore


### PR DESCRIPTION
## 变更内容

- 为 `click`、`fill`、`select` 的失败结果附带最新的 `full` 浏览器状态
- 将参数缺失、失效 ref、元素类型不支持和执行异常统一为结构化 `isError` 结果
- MCP 调用直接返回失败原因与最新状态
- 事件调用返回 `success: false`、`error` 和包含浏览器状态的 `result`

## 变更原因

操作失败经常由页面刷新后 ref/id 失效导致。此前失败结果缺少最新页面状态，调用方需要额外请求一次浏览器状态才能继续操作。

## 影响

失败后的 MCP 与事件调用方都能立即获得最新页面树并使用新的 ref 继续操作；成功路径保持不变。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for click, fill, and select actions with clearer validation messages and retry guidance.
  * Automatically refreshes browser state when an element reference is stale or invalid.
  * Tool execution errors are now consistently reported as failed results instead of being treated as successful responses.
  * Ensures page masks are hidden when action errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->