### PR TITLE
fix: 添加CHAT-END 事件以及 removeMaskAterToolCall 选项

### DIFF
--- a/packages/next-sdk/page-tools/page-agent-tool-event.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool-event.ts
@@ -96,8 +96,10 @@ export function setupPageAgentToolEventBridge(
   }
 
   // 聊天结束事件，用于在聊天结束时移除遮罩
-  const handleChatEnd = () => {
-    pageController.hideMask()
+  const handleChatEnd = async () => {
+    try {
+      await pageController.hideMask()
+    } catch (error) {}
   }
 
   window.addEventListener(PAGE_AGENT_TOOL_CALL_EVENT, handleToolCall)

--- a/packages/next-sdk/page-tools/page-agent-tool-event.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool-event.ts
@@ -1,7 +1,9 @@
 import { inputSchema, type PageAgentToolInput, type PageAgentToolRawInput } from './schema'
+import { PageController } from '@page-agent/page-controller'
 
 export const PAGE_AGENT_TOOL_CALL_EVENT = 'page-agent-tool-call'
 export const PAGE_AGENT_TOOL_RESULT_EVENT = 'page-agent-tool-result'
+export const PAGE_AGENT_CHAT_END_EVENT = 'page-agent-chat-end'
 
 export type PageAgentToolCallEventDetail = {
   data?: PageAgentToolRawInput
@@ -40,7 +42,10 @@ function dispatchPageAgentToolResult(detail: PageAgentToolResultEventDetail) {
   window.dispatchEvent(new CustomEvent(PAGE_AGENT_TOOL_RESULT_EVENT, { detail }))
 }
 
-export function setupPageAgentToolEventBridge(executePageAgentTool: ExecutePageAgentTool) {
+export function setupPageAgentToolEventBridge(
+  executePageAgentTool: ExecutePageAgentTool,
+  pageController: PageController
+) {
   window.__nextSdkPageAgentToolEventCleanup?.()
 
   const handleToolCall = async (event: Event) => {
@@ -90,9 +95,17 @@ export function setupPageAgentToolEventBridge(executePageAgentTool: ExecutePageA
     }
   }
 
+  // 聊天结束事件，用于在聊天结束时移除遮罩
+  const handleChatEnd = () => {
+    pageController.hideMask()
+  }
+
   window.addEventListener(PAGE_AGENT_TOOL_CALL_EVENT, handleToolCall)
+  window.addEventListener(PAGE_AGENT_CHAT_END_EVENT, handleChatEnd)
+
   window.__nextSdkPageAgentToolEventCleanup = () => {
     window.removeEventListener(PAGE_AGENT_TOOL_CALL_EVENT, handleToolCall)
+    window.removeEventListener(PAGE_AGENT_CHAT_END_EVENT, handleChatEnd)
     window.__nextSdkPageAgentToolEventCleanup = undefined
   }
 }

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -26,6 +26,10 @@ import { handleSearchTree } from './handlers/searchTree'
 export function registerPageAgentTool(options: PageAgentToolOptions = {}) {
   initializeBuiltinWebMCP()
 
+  if (typeof options.removeMaskAterToolCall === 'undefined') {
+    options.removeMaskAterToolCall = true
+  }
+
   // 完整工具配置（顶层选项 enableHighlight + 统一无障碍配置 a11yConfig）：与默认配置合并后
   // 得到运行期唯一生效的配置（存于 window.__webmcpcli_toolConfig），后续可通过
   // setPageAgentToolConfig 在运行期继续修改（追加式合并/函数式过滤/整体替换）

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -141,26 +141,26 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}) {
           pageController.mask.borderElement(currentRefMap.get(args.index))
           ret = await handleClick(args, actionContext)
           pageController.mask.removeBorderElement()
-          await pageController.hideMask()
+          options.removeMaskAterToolCall && (await pageController.hideMask())
           break
         case 'fill':
           await pageController.showMask()
           pageController.mask.borderElement(currentRefMap.get(args.index))
           ret = await handleFill(args, actionContext)
           pageController.mask.removeBorderElement()
-          await pageController.hideMask()
+          options.removeMaskAterToolCall && (await pageController.hideMask())
           break
         case 'select':
           await pageController.showMask()
           pageController.mask.borderElement(currentRefMap.get(args.index))
           ret = await handleSelect(args, actionContext)
           pageController.mask.removeBorderElement()
-          await pageController.hideMask()
+          options.removeMaskAterToolCall && (await pageController.hideMask())
           break
         case 'scroll':
           await pageController.showMask()
           ret = await handleScroll(args, actionContext)
-          await pageController.hideMask()
+          options.removeMaskAterToolCall && (await pageController.hideMask())
           break
         case 'executeJavascript':
           ret = await handleExecuteJavascript(args, actionContext)
@@ -183,7 +183,7 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}) {
           `${actionNames[args.action as keyof typeof actionNames]}执行异常: ${error instanceof Error ? error.message : String(error)}`
         )
       }
-      await pageController.hideMask()
+      options.removeMaskAterToolCall && (await pageController.hideMask())
       throw error
     }
   }
@@ -203,5 +203,5 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}) {
     }
   })
 
-  setupPageAgentToolEventBridge(executePageAgentTool)
+  setupPageAgentToolEventBridge(executePageAgentTool,pageController)
 }

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -55,7 +55,7 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}) {
 
   async function actionError(msg: string) {
     const result = await createActionErrorResult(msg, buildBrowserStateResponse)
-    await pageController.hideMask()
+    options.removeMaskAterToolCall && (await pageController.hideMask())
     return result
   }
 
@@ -203,5 +203,5 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}) {
     }
   })
 
-  setupPageAgentToolEventBridge(executePageAgentTool,pageController)
+  setupPageAgentToolEventBridge(executePageAgentTool, pageController)
 }

--- a/packages/next-sdk/page-tools/tool-config.ts
+++ b/packages/next-sdk/page-tools/tool-config.ts
@@ -26,6 +26,9 @@ export interface PageAgentToolConfig {
 export interface PageAgentToolConfigPatch {
   /** 是否启用元素高亮 */
   enableHighlight?: boolean
+  /** 是否在工具调用后移除遮罩， 默认值为 false 不移除 */
+  removeMaskAterToolCall?: boolean
+  /** 是否在工具调用后移除遮罩 */
   /** 统一无障碍配置，会与当前生效的 a11yConfig 按数组拼接合并 */
   a11yConfig?: A11yConfig
 }
@@ -36,7 +39,7 @@ export type PageAgentToolOptions = PageAgentToolConfigPatch
 /** 默认生效的完整工具配置 */
 export const DEFAULT_PAGE_AGENT_TOOL_CONFIG: PageAgentToolConfig = {
   enableHighlight: false,
-  a11yConfig: DEFAULT_A11Y_CONFIG,
+  a11yConfig: DEFAULT_A11Y_CONFIG
 }
 
 declare global {
@@ -57,7 +60,7 @@ export function getPageAgentToolConfig(): PageAgentToolConfig {
 function resolvePatch(patch: PageAgentToolConfigPatch, base: PageAgentToolConfig): PageAgentToolConfig {
   return {
     enableHighlight: patch.enableHighlight ?? base.enableHighlight,
-    a11yConfig: mergeA11yConfigs(base.a11yConfig, patch.a11yConfig ?? {}),
+    a11yConfig: mergeA11yConfigs(base.a11yConfig, patch.a11yConfig ?? {})
   }
 }
 
@@ -72,14 +75,15 @@ function resolvePatch(patch: PageAgentToolConfigPatch, base: PageAgentToolConfig
  */
 export function setPageAgentToolConfig(
   patch: PageAgentToolConfigPatch | ((current: PageAgentToolConfig) => PageAgentToolConfigPatch),
-  options?: { mode?: 'merge' | 'replace' },
+  options?: { mode?: 'merge' | 'replace' }
 ): PageAgentToolConfig {
   const mode = options?.mode ?? 'merge'
   const current = getPageAgentToolConfig()
 
-  const next = typeof patch === 'function'
-    ? resolvePatch(patch(current), DEFAULT_PAGE_AGENT_TOOL_CONFIG)
-    : resolvePatch(patch, mode === 'replace' ? DEFAULT_PAGE_AGENT_TOOL_CONFIG : current)
+  const next =
+    typeof patch === 'function'
+      ? resolvePatch(patch(current), DEFAULT_PAGE_AGENT_TOOL_CONFIG)
+      : resolvePatch(patch, mode === 'replace' ? DEFAULT_PAGE_AGENT_TOOL_CONFIG : current)
 
   if (typeof window !== 'undefined') {
     window.__webmcpcli_toolConfig = next

--- a/packages/next-sdk/page-tools/tool-config.ts
+++ b/packages/next-sdk/page-tools/tool-config.ts
@@ -26,7 +26,7 @@ export interface PageAgentToolConfig {
 export interface PageAgentToolConfigPatch {
   /** 是否启用元素高亮 */
   enableHighlight?: boolean
-  /** 是否在工具调用后移除遮罩， 默认值为 false 不移除 */
+  /** 是否在工具调用后移除遮罩， 默认值为 true 移除 */
   removeMaskAterToolCall?: boolean
   /** 是否在工具调用后移除遮罩 */
   /** 统一无障碍配置，会与当前生效的 a11yConfig 按数组拼接合并 */


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)

1.  window上发送一个事件， 'page-agent-chat-end'  来关闭层
2. 选项增加removeMaskAterToolCall ， 默认值为 true 自动关闭


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/next-sdk/blob/dev/CONTRIBUTING.md#pull-request-specification)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation-related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The page mask now closes automatically when an agent chat ends.
  - Added an option to control whether the page mask is removed after tool actions (enabled by default).

- **Bug Fixes**
  - Improved mask behavior so it’s hidden only after click, fill, select, scroll, and error outcomes when mask removal is enabled.
  - Prevented the mask from being hidden when automatic removal is disabled.
  - Enhanced event listener cleanup to improve reliability across repeated interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->