### PR TITLE
feat(next-sdk): expose registerPageAgentTool  mask handle

### DIFF
--- a/packages/next-sdk/index.ts
+++ b/packages/next-sdk/index.ts
@@ -54,6 +54,7 @@ export * from '@mcp-b/webmcp-polyfill'
 
 export { initializeBuiltinWebMCP } from './page-tools/initialize-builtin-WebMCP'
 export { registerPageAgentTool } from './page-tools/page-agent-tool'
+export type { PageAgentToolHandle } from './page-tools/page-agent-tool'
 export { PAGE_AGENT_TOOL_CALL_EVENT, PAGE_AGENT_TOOL_RESULT_EVENT } from './page-tools/page-agent-tool-event'
 export type { PageAgentToolCallEventDetail, PageAgentToolResultEventDetail } from './page-tools/page-agent-tool-event'
 export type { PageAgentToolOptions } from './page-tools/tool-config'

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -23,8 +23,14 @@ import { handleExecuteJavascript } from './handlers/executeJavascript'
 import { handleSearchTree } from './handlers/searchTree'
 import { handleHover } from './handlers/hover'
 
+/** registerPageAgentTool 返回的句柄，暴露对内部 PageController mask 显隐的控制 */
+export type PageAgentToolHandle = {
+  showMask: () => Promise<void>
+  hideMask: () => Promise<void>
+}
+
 /** 在浏览器页面中注册 page-agent-tool, 用于页面的内容获取和操作，页面的动效 */
-export function registerPageAgentTool(options: PageAgentToolOptions = {}) {
+export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageAgentToolHandle {
   initializeBuiltinWebMCP()
 
   // 完整工具配置（顶层选项 enableHighlight + 统一无障碍配置 a11yConfig）：与默认配置合并后
@@ -223,4 +229,9 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}) {
   })
 
   setupPageAgentToolEventBridge(executePageAgentTool, pageController)
+
+  return {
+    showMask: () => pageController.showMask(),
+    hideMask: () => pageController.hideMask()
+  }
 }

--- a/packages/next-sdk/specs/REQ-20260722-mask-handle/design.md
+++ b/packages/next-sdk/specs/REQ-20260722-mask-handle/design.md
@@ -1,0 +1,22 @@
+# Design：registerPageAgentTool 暴露 mask 显隐句柄
+
+## 方案概述
+
+在 `registerPageAgentTool` 末尾返回 `{ showMask, hideMask }`，箭头函数透传到内部 `pageController` 的同名方法；新增 `PageAgentToolHandle` 类型并从入口导出。
+
+## 涉及文件
+
+- `packages/next-sdk/page-tools/page-agent-tool.ts`：新增类型、声明返回类型、返回句柄。
+- `packages/next-sdk/index.ts`：`export type { PageAgentToolHandle }`。
+
+## API / 行为变更
+
+| 符号或行为                       | 变更类型 | 说明                             |
+| -------------------------------- | -------- | -------------------------------- |
+| `registerPageAgentTool()` 返回值 | 新增     | 由 `void` 改为 `PageAgentToolHandle`，向后兼容 |
+| `PageAgentToolHandle` 类型       | 新增     | 从包入口导出                     |
+
+## 风险与兼容
+
+- 仅新增返回值与类型导出，现有调用方均丢弃返回值，无破坏性变更。
+- 句柄方法不读取 `removeMaskAfterToolCall`，公开 API 为显式控制。

--- a/packages/next-sdk/specs/REQ-20260722-mask-handle/requirements.md
+++ b/packages/next-sdk/specs/REQ-20260722-mask-handle/requirements.md
@@ -1,0 +1,28 @@
+# Spec：registerPageAgentTool 暴露 mask 显隐句柄
+
+## 元信息
+
+- 状态：已交付
+- 主责包：`packages/next-sdk`
+- 关联 PR：opentiny/webmcp-sdk#520
+
+## 背景
+
+`registerPageAgentTool` 内部持有一份 `PageController`，但此前无返回值，宿主页面无法在非工具调用时机主动控制 mask。本次开放最小句柄，把已有的 `showMask/hideMask` 透出。
+
+## 范围
+
+### In Scope
+
+- `registerPageAgentTool` 返回 `{ showMask, hideMask }`。
+- 新增并导出 `PageAgentToolHandle` 类型。
+
+### Out of Scope
+
+- mask 行为 / 配置项变更。
+- 调用方接入（各包按需消费）。
+
+## 验收标准
+
+1. `const h = registerPageAgentTool(); await h.showMask(); await h.hideMask();` 正常工作。
+2. `PageAgentToolHandle` 类型可从 `@opentiny/next-sdk` 导入，`tsc --noEmit` 无报错。

--- a/packages/next-sdk/specs/REQ-20260722-mask-handle/tasks.md
+++ b/packages/next-sdk/specs/REQ-20260722-mask-handle/tasks.md
@@ -1,0 +1,14 @@
+# Tasks：registerPageAgentTool 暴露 mask 显隐句柄
+
+- [x] Task 1: 返回 `{ showMask, hideMask }` 并新增 `PageAgentToolHandle` 类型
+  - 产物：`packages/next-sdk/page-tools/page-agent-tool.ts`
+- [x] Task 2: 从包入口导出新类型
+  - 产物：`packages/next-sdk/index.ts` 补 `export type { PageAgentToolHandle }`
+- [x] Task 3: 测试与构建无回归
+
+## 验收命令
+
+```bash
+pnpm -F @opentiny/next-sdk test
+pnpm -F @opentiny/next-sdk build
+```

--- a/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
+++ b/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 // jsdom 无 WebGL2，避免 SimulatorMask → ai-motion 初始化刷 stderr
+// show/hide 委托到模块级 spy，便于在句柄测试中断言 pageController.showMask/hideMask 是否触达 mask
+const maskSpies = vi.hoisted(() => ({ show: vi.fn(), hide: vi.fn() }))
 vi.mock('../../page-tools/page-agent-mask/SimulatorMask', () => ({
   SimulatorMask: class SimulatorMask {
-    show() {}
-    hide() {}
+    show() {
+      maskSpies.show()
+    }
+    hide() {
+      maskSpies.hide()
+    }
     dispose() {}
   },
 }))
@@ -22,6 +28,8 @@ function resetWindowGlobals() {
 
 beforeEach(() => {
   resetWindowGlobals()
+  maskSpies.show.mockClear()
+  maskSpies.hide.mockClear()
 })
 
 afterEach(() => {
@@ -100,5 +108,23 @@ describe('registerPageAgentTool - 顶层工具配置（PageAgentToolConfig）接
     })
     expect(getPageAgentToolConfig().enableHighlight).toBe(false)
     expect(getPageAgentToolConfig().a11yConfig.roles.filter((r) => r.role === 'tab')).toEqual([{ role: 'tab', selector: '.tab-item' }])
+  })
+})
+
+describe('registerPageAgentTool - mask 显隐句柄', () => {
+  it('返回值包含 showMask / hideMask 两个函数', () => {
+    const handle = registerPageAgentTool()
+    expect(typeof handle.showMask).toBe('function')
+    expect(typeof handle.hideMask).toBe('function')
+  })
+
+  it('handle.showMask() 触发 SimulatorMask.show，handle.hideMask() 触发 SimulatorMask.hide', async () => {
+    const handle = registerPageAgentTool()
+    await handle.showMask()
+    expect(maskSpies.show).toHaveBeenCalledTimes(1)
+    expect(maskSpies.hide).not.toHaveBeenCalled()
+
+    await handle.hideMask()
+    expect(maskSpies.hide).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary
- `registerPageAgentTool` 返回值新增 `showMask` / `hideMask` 方法，将内部 `PageController` 的 mask 显隐控制暴露给调用方。
- 新增并导出 `PageAgentToolHandle` 类型，为返回值提供显式类型声明，便于消费方获得类型提示。

## 使用场景
使用NPM场景/Runtime场景 需要主动控制Mask时使用

> 以下标题与勾选格式供 CI（PR Gate）解析，**请勿改章节标题文案**。

## PR Type

What kind of change does this PR introduce?（有且仅有一个 `[x]`）

- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation-related changes
- [ ] Other

## PR Checklist

- [ ] Commit / PR 标题符合 `type(scope): subject`（见 CONTRIBUTING）
- [ ] 已按类型填写下方 Gate Fields
- [ ] Bug fix：已补充中文复现测试（`复现：`）
- [x] Feature：已关联包内 Spec（`packages/<pkg>/specs/REQ-20260722-mask-handle/`）
- [ ] Docs 已按需更新
- [ ] Refactoring：无行为变更或已补回归 / 已填 Skip reason
- [ ] Other：已在说明中写清原因

## Gate Fields（CI 读取，请按类型填写）

- Issue: 
- Spec:  packages/next-sdk/specs/REQ-20260722-mask-handle/
- Repro test: 
- Skip reason: 

（Bug fix 必填 Repro test；Issue 可选。Feature 必填 Spec；豁免时填 Skip reason。）

## What is the current behavior?

Issue Number: 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a public control handle for registered page agent tools.
  * Applications can now programmatically show or hide the page mask via async `showMask()` / `hideMask()`.
* **API Updates**
  * Updated `registerPageAgentTool` to return the new handle object.
  * Exposed the `PageAgentToolHandle` type via the SDK’s public API.
* **Documentation**
  * Added design and requirements documentation for the new mask handle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->