### PR TITLE
fix:next-remoter构建出现oom

### DIFF
--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -24,11 +24,31 @@
   ],
   "module": "./src/index.ts",
   "types": "./src/index.ts",
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
+    }
+  },
   "publishConfig": {
     "access": "public",
     "module": "dist/next-remoter.es.js",
     "main": "dist/next-remoter.cjs.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "exports": {
+      ".": {
+        "import": "./dist/next-remoter.es.js",
+        "require": "./dist/next-remoter.cjs.js",
+        "types": "./dist/index.d.ts"
+      },
+      "./dist/style.css": "./dist/style.css"
+    },
+    "sideEffects": [
+      "**/*.css"
+    ]
   },
   "scripts": {
     "dev": "vite",

--- a/packages/next-remoter/vite.config.ts
+++ b/packages/next-remoter/vite.config.ts
@@ -1,5 +1,6 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { readFileSync } from 'node:fs'
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import Components from 'unplugin-vue-components/vite'
@@ -10,6 +11,14 @@ import { VantResolver } from '@vant/auto-import-resolver'
 import { visualizer } from 'rollup-plugin-visualizer'
 import dts from 'vite-plugin-dts'
 const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// 读取 package.json 中的依赖列表，构建时全部 external 化
+// 库构建不应内联依赖，否则产物体积膨胀且消费方无法 tree-shake
+const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8'))
+const externalDeps = [
+  ...Object.keys(pkg.dependencies || {}),
+  ...Object.keys(pkg.peerDependencies || {})
+]
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -53,21 +62,11 @@ export default defineConfig(({ mode }) => {
         fileName: (format) => `next-remoter.${format}.js`
       },
       rollupOptions: {
-        // external 函数：排除 JS 模块，但不排除 CSS 文件
+        // external 策略：将 package.json 中声明的所有依赖外部化
+        // CSS 文件不排除（需打包到 style.css）
         external: (id) => {
-          // CSS 文件不应该被排除，需要打包到 style.css
-          if (id.endsWith('.css')) {
-            return false
-          }
-          // 排除 vue
-          if (id === 'vue') {
-            return true
-          }
-          // 排除 @opentiny/ 开头的 JS 模块，但不排除 CSS 文件
-          if (id.startsWith('@opentiny/')) {
-            return true
-          }
-          return false
+          if (id.endsWith('.css')) return false
+          return externalDeps.some(dep => id === dep || id.startsWith(dep + '/'))
         },
         output: {
           // CSS 文件使用 style.css 作为文件名，其他资源保持默认命名


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)
fix:next-remoter构建出现oom

> 以下标题与勾选格式供 CI（PR Gate）解析，**请勿改章节标题文案**。

## PR Type

What kind of change does this PR introduce?（有且仅有一个 `[x]`）

- [ ] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation-related changes
- [x] Other

## PR Checklist

- [ ] Commit / PR 标题符合 `type(scope): subject`（见 CONTRIBUTING）
- [ ] 已按类型填写下方 Gate Fields
- [ ] Bug fix：已补充中文复现测试（`复现：`）
- [ ] Feature：已关联包内 Spec（`packages/<pkg>/specs/REQ-.../`）
- [ ] Docs 已按需更新
- [ ] Refactoring：无行为变更或已补回归 / 已填 Skip reason
- [x] Other：已在说明中写清原因

## Gate Fields（CI 读取，请按类型填写）

- Issue: 
- Spec: 
- Repro test: 
- Skip reason: 

（Bug fix 必填 Repro test；Issue 可选。Feature 必填 Spec；豁免时填 Skip reason。）

## What is the current behavior?

Issue Number:  #495

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved package entrypoint and stylesheet resolution for different module systems and TypeScript consumers.
  * Added clearer package metadata to preserve CSS assets during bundling and publishing.

* **Bug Fixes**
  * Improved build behavior by correctly externalizing declared dependencies while bundling stylesheet imports as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->