### PR TITLE
chore: bump versions to 0.4.4 and add es module format support to next-sdk runtime build

### DIFF
--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-remoter",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/tiny-robot-remoter.html",
   "repository": {

--- a/packages/next-sdk/package.json
+++ b/packages/next-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-sdk",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/",
   "repository": {

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -218,7 +218,10 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
   const modelContext = (document as any).modelContext
   if (!modelContext) {
     console.warn('[next-sdk] modelContext is not available, skipping page-agent-tool registration.')
-    return
+    return {
+      showMask: () => pageController.showMask(),
+      hideMask: () => pageController.hideMask()
+    }
   }
   try {
     modelContext.unregisterTool?.('page-agent-tool')

--- a/packages/next-sdk/vite.config.runtime.ts
+++ b/packages/next-sdk/vite.config.runtime.ts
@@ -10,8 +10,8 @@ export default defineConfig(() => {
       lib: {
         entry: 'runtime.ts',
         name: 'WebMCPSDK',
-        formats: ['iife'] as any,
-        fileName: () => 'runtime.js'
+        formats: ['iife', 'es'],
+        fileName: (format) => format === 'es' ? 'runtime.es.js' : 'runtime.js'
       },
       rollupOptions: {
         // 全量打包第三方依赖，便于浏览器中直接注入或运行

--- a/packages/next-sdk/vite.config.runtime.ts
+++ b/packages/next-sdk/vite.config.runtime.ts
@@ -15,7 +15,10 @@ export default defineConfig(() => {
       },
       rollupOptions: {
         // 全量打包第三方依赖，便于浏览器中直接注入或运行
-        external: []
+        external: [],
+        output: {
+          inlineDynamicImports: true
+        }
       }
     }
   }


### PR DESCRIPTION

# Pull Request (OpenTiny NEXT-SDKs)

> 以下标题与勾选格式供 CI（PR Gate）解析，**请勿改章节标题文案**。

## PR Type

What kind of change does this PR introduce?（有且仅有一个 `[x]`）

- [ ] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation-related changes
- [x] Other

## PR Checklist

- [ ] Commit / PR 标题符合 `type(scope): subject`（见 CONTRIBUTING）
- [ ] 已按类型填写下方 Gate Fields
- [ ] Bug fix：已补充中文复现测试（`复现：`）
- [ ] Feature：已关联包内 Spec（`packages/<pkg>/specs/REQ-.../`）
- [ ] Docs 已按需更新
- [ ] Refactoring：无行为变更或已补回归 / 已填 Skip reason
- [x] Other：已在说明中写清原因

## Gate Fields（CI 读取，请按类型填写）

- Issue: 
- Spec: 
- Repro test: 
- Skip reason: 本次提交，不是新特性

（Bug fix 必填 Repro test；Issue 可选。Feature 必填 Spec；豁免时填 Skip reason。）

## What is the current behavior?

Issue Number: 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when page-agent tools are initialized before required browser context is available.
  * Page-agent tool controls now remain available for showing and hiding the page mask in this scenario.

* **Improvements**
  * Enhanced runtime distribution with both modern ES module and bundled formats.

* **Release**
  * Updated the SDK and remoter packages to version 0.4.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->