### PR TITLE
fix: correct some spelling errors

### DIFF
--- a/docs/guide/choose-scene.md
+++ b/docs/guide/choose-scene.md
@@ -13,7 +13,7 @@ outline: [2, 3]
 
 ### 1. 智能化应用场景
 
-**智能化应用场景**是用户在开发项目网站时，引入WebMCP SDLs后，注册一组页面工具函数，以便AI 大模型可以直接读取和控制网站应用，将应用变得 AI 驱动式应用。
+**智能化应用场景**是用户在开发项目网站时，引入WebMCP SDKs后，注册一组页面工具函数，以便AI 大模型可以直接读取和控制网站应用，将应用变得 AI 驱动式应用。
 
 当网站项目已经智能化之后，我们就可以通过一定的手段将页面工具传递给 AI 大模型，最简单就是引入 `Tiny Remoter`的Vue组件。如果你想深度定制UI与交互逻辑，你也可以直接选择 `Tiny Robot`组件库进行从零开发您的智能体程序, 智能化应用场景结构图如下。
 
@@ -31,10 +31,10 @@ outline: [2, 3]
 
 ![remoter.png](./remoter.png)
 
-从上图可以看到，整个架构包含 5 个角色，其中**Web Agent 服务**和 **遥控网站**需要额外部署，参见[私有化部署方案](../remoter/remoter-mode.md)：
+从上图可以看到，整个架构包含 5 个角色，其中**WebAgent 服务**和 **遥控网站**需要额外部署，参见[私有化部署方案](../remoter/remoter-mode.md)：
 
-- **Web Page 应用**：用户正在开发的业务页面，需注册网页工具并向 `Web Agent` 服务注册，完成网页智能化改造。
-- **Web Agent 服务**：本地部署的 Node.js 后端应用，作为智能代理中枢和 MCP 代理转发服务,。它接收页面的连接信息后，生成 `sessionId` 后与目标页面建立连接，同时创建标准的 HTTP Streamable MCP Server。任意 MCP Client 均可连接并调用其工具，调用会转发至目标页面。
+- **Web Page 应用**：用户正在开发的业务页面，需注册网页工具并向 `WebAgent` 服务注册，完成网页智能化改造。
+- **WebAgent 服务**：本地部署的 Node.js 后端应用，作为智能代理中枢和 MCP 代理转发服务,。它接收页面的连接信息后，生成 `sessionId` 后与目标页面建立连接，同时创建标准的 HTTP Streamable MCP Server。任意 MCP Client 均可连接并调用其工具，调用会转发至目标页面。
 - **Remoter 组件**：在系统中嵌入聊天界面，它本身也是前端智能体，内部可以添加 McpServer，并与 AI 大模型直接对话。当它接收当前页面的 `sessionId` 后，会创建 MCP Client 控制当前页面。
 - **遥控网站**：一个部署的 Vue 项目, 通过 URL 参数接收 `sessionId`后，创建 MCP Client 控制目标页面。
 - **LLM 大模型**：为 Remoter 组件或遥控网站提供 AI 对话能力
@@ -43,10 +43,10 @@ outline: [2, 3]
 
 远程遥控场景的总结：
 
-1.  Web Page 应用 和 Web Agent 服务 是组成一个的最小系统，并向外提供一个**标准 MCP Server 服务**。这个服务可被任意智能体访问。
+1.  Web Page 应用 和 WebAgent 服务 是组成一个的最小系统，并向外提供一个**标准 MCP Server 服务**。这个服务可被任意智能体访问。
 2.  Remoter 组件 和 遥控网站 均为可选角色,它们自身是前端智能体，与 AI 大模型直接对话，并可使用**标准 MCP Server 服务**。
 3.  第三方智能体 VS Code、CodeX、OpenCode 等，也可以配置McpServer来使用它。
-4.  `TinyRemoter` 是整个架构的枢纽组件，Remoter 组件和遥控网站中的对话框均使用该组件开发。它一边接收页面的 `sessionId`，一边与 `Web Agent` 服务和 LLM 大模型建立连接，打通整个 AI 对话流程。
+4.  `TinyRemoter` 是整个架构的枢纽组件，Remoter 组件和遥控网站中的对话框均使用该组件开发。它一边接收页面的 `sessionId`，一边与 `WebAgent` 服务和 LLM 大模型建立连接，打通整个 AI 对话流程。
 
 ---
 
@@ -76,11 +76,11 @@ outline: [2, 3]
 
 我们推荐使用**内联式**工具， 因为只有应用自己了解自己，**内联式**可以编程式开发，打通应用内部数据和函数，一次执行多步的任务，且动作是准确可预测的。通过定义网页工具函数，可以实现许多外挂式/视觉式工具无法实现的能力。
 
-### 2. 为什么选择WebMcp API
+### 2. 为什么选择WebMCP API
 
-**OpenTiny WebMCP-SDKs** 是探索WebMcp的先行者，自2025年就在浏览器上定义WebMcp Server,并进行注册工具函数，详见：[WebMcp Server](../webmcp-sdk/webmcp-server.md)。
+**OpenTiny WebMCP-SDKs** 是探索WebMCP的先行者，自2025年就在浏览器上定义WebMCP Server,并进行注册工具函数，详见：[WebMCP Server](../webmcp-sdk/webmcp-server.md)。
 
-在2006.5.27号会议上， W3C 组织已经定义标准**WebMCP API**，并将在 Chrome 150 上正式推出。目前已经有成熟的 WebMcp Polyfill包，可以让我们在低版本浏览器上也能使用它，所以它目前已经是广泛可用的状态了。
+在2026.5.27号会议上， W3C 组织已经定义标准**WebMCP API**，并将在 Chrome 150 上正式推出。目前已经有成熟的 WebMCP Polyfill包，可以让我们在低版本浏览器上也能使用它，所以它目前已经是广泛可用的状态了。
 随着它成为浏览器标准API并逐渐流行后，未来大多数网页应用都会内部集成WebMCP API， AI 智能体将可以无缝操作这些网站。
 
-我们定义的WebMcp Server 与 标准WebMCP API的功能目的是一致的，用法是一致的。当WebMCP API成为标准后， 我们不建议继续使用WebMcp Server。
+我们定义的WebMCP Server 与 标准WebMCP API的功能目的是一致的，用法是一致的。当WebMCP API成为标准后， 我们不建议继续使用WebMCP Server。

--- a/docs/guide/choose-scene.md
+++ b/docs/guide/choose-scene.md
@@ -34,7 +34,7 @@ outline: [2, 3]
 从上图可以看到，整个架构包含 5 个角色，其中**WebAgent 服务**和 **遥控网站**需要额外部署，参见[私有化部署方案](../remoter/remoter-mode.md)：
 
 - **Web Page 应用**：用户正在开发的业务页面，需注册网页工具并向 `WebAgent` 服务注册，完成网页智能化改造。
-- **WebAgent 服务**：本地部署的 Node.js 后端应用，作为智能代理中枢和 MCP 代理转发服务,。它接收页面的连接信息后，生成 `sessionId` 后与目标页面建立连接，同时创建标准的 HTTP Streamable MCP Server。任意 MCP Client 均可连接并调用其工具，调用会转发至目标页面。
+- **WebAgent 服务**：本地部署的 Node.js 后端应用，作为智能代理中枢和 MCP 代理转发服务。它接收页面的连接信息后，生成 `sessionId` 后与目标页面建立连接，同时创建标准的 HTTP Streamable MCP Server。任意 MCP Client 均可连接并调用其工具，调用会转发至目标页面。
 - **Remoter 组件**：在系统中嵌入聊天界面，它本身也是前端智能体，内部可以添加 McpServer，并与 AI 大模型直接对话。当它接收当前页面的 `sessionId` 后，会创建 MCP Client 控制当前页面。
 - **遥控网站**：一个部署的 Vue 项目, 通过 URL 参数接收 `sessionId`后，创建 MCP Client 控制目标页面。
 - **LLM 大模型**：为 Remoter 组件或遥控网站提供 AI 对话能力
@@ -45,7 +45,7 @@ outline: [2, 3]
 
 1.  Web Page 应用 和 WebAgent 服务 是组成一个的最小系统，并向外提供一个**标准 MCP Server 服务**。这个服务可被任意智能体访问。
 2.  Remoter 组件 和 遥控网站 均为可选角色,它们自身是前端智能体，与 AI 大模型直接对话，并可使用**标准 MCP Server 服务**。
-3.  第三方智能体 VS Code、CodeX、OpenCode 等，也可以配置McpServer来使用它。
+3.  第三方智能体 VS Code、CodeX、OpenCode 等，也可以配置 Mcp Server 来使用它。
 4.  `TinyRemoter` 是整个架构的枢纽组件，Remoter 组件和遥控网站中的对话框均使用该组件开发。它一边接收页面的 `sessionId`，一边与 `WebAgent` 服务和 LLM 大模型建立连接，打通整个 AI 对话流程。
 
 ---
@@ -80,7 +80,7 @@ outline: [2, 3]
 
 **OpenTiny WebMCP-SDKs** 是探索WebMCP的先行者，自2025年就在浏览器上定义WebMCP Server,并进行注册工具函数，详见：[WebMCP Server](../webmcp-sdk/webmcp-server.md)。
 
-在2026.5.27号会议上， W3C 组织已经定义标准**WebMCP API**，并将在 Chrome 150 上正式推出。目前已经有成熟的 WebMCP Polyfill包，可以让我们在低版本浏览器上也能使用它，所以它目前已经是广泛可用的状态了。
+浏览器上标准**WebMCP API**目前仍是实验特性，最新标准将在 Chrome 150 上正式推出。目前已经有成熟的 WebMCP Polyfill包，可以让我们在低版本浏览器上也能使用它，所以它目前已经是广泛可用的状态了。
 随着它成为浏览器标准API并逐渐流行后，未来大多数网页应用都会内部集成WebMCP API， AI 智能体将可以无缝操作这些网站。
 
 我们定义的WebMCP Server 与 标准WebMCP API的功能目的是一致的，用法是一致的。当WebMCP API成为标准后， 我们不建议继续使用WebMCP Server。

--- a/docs/guide/choose-scene.md
+++ b/docs/guide/choose-scene.md
@@ -45,7 +45,7 @@ outline: [2, 3]
 
 1.  Web Page 应用 和 WebAgent 服务 是组成一个的最小系统，并向外提供一个**标准 MCP Server 服务**。这个服务可被任意智能体访问。
 2.  Remoter 组件 和 遥控网站 均为可选角色,它们自身是前端智能体，与 AI 大模型直接对话，并可使用**标准 MCP Server 服务**。
-3.  第三方智能体 VS Code、CodeX、OpenCode 等，也可以配置 Mcp Server 来使用它。
+3.  第三方智能体 VS Code、CodeX、OpenCode 等，也可以配置 MCP Server 来使用它。
 4.  `TinyRemoter` 是整个架构的枢纽组件，Remoter 组件和遥控网站中的对话框均使用该组件开发。它一边接收页面的 `sessionId`，一边与 `WebAgent` 服务和 LLM 大模型建立连接，打通整个 AI 对话流程。
 
 ---

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -169,7 +169,7 @@ if (sessionId) {
 }
 ```
 
-`WebAgent` 服务向外提供的是一个标准的`Mcp Server`，通过`sessionId` 实现在AI 智能体上来遥控网页。比如：
+`WebAgent` 服务向外提供的是一个标准的`MCP Server`，通过`sessionId` 实现在AI 智能体上来遥控网页。比如：
 
 - 对接TinyRemoter对话组件
 - 对接遥控网站

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -140,15 +140,15 @@ const llmConfig = {
 
 ## 三、增加远程遥控能力
 
-你可以将页面连接到 `Web Agent` 后台代理服务，之后就可以通过`Web Agent` 后台代理来`远程遥控`该页面。`Web Agent` 后台代理提供的是一个标准的`Mcp Server`服务，所以它可以方便接入许多智能体，实现跨应用或跨主机的`远程遥控`的功能。
+你可以将页面连接到 `WebAgent` 后台代理服务，之后就可以通过`WebAgent` 后台代理来`远程遥控`该页面。`WebAgent` 后台代理提供的是一个标准的`Mcp Server`服务，所以它可以方便接入许多智能体，实现跨应用或跨主机的`远程遥控`的功能。
 
 `sessionId` 是连接凭证，通过它可以定位到操作页面。当页面关闭后，该`sessionId`会自动失效。
 
-::: tip Web Agent 服务
-Web Agent 服务是一个提前部署的 Node.js 后端应用，部署方法详见 [Web Agent 文档](https://docs.opentiny.design/web-agent/guide/getting-started) 或 [Web Agent 仓库](https://github.com/opentiny/web-agent/blob/main/README.zh-CN.md)。
+::: tip WebAgent 服务
+WebAgent 服务是一个提前部署的 Node.js 后端应用，部署方法详见 [WebAgent 文档](https://docs.opentiny.design/web-agent/guide/getting-started) 或 [WebAgent 仓库](https://github.com/opentiny/web-agent/blob/main/README.zh-CN.md)。
 :::
 
-连接到 `Web Agent` 示例代码如下：
+连接到 `WebAgent` 示例代码如下：
 
 ```typescript
 import { WebMcpClient } from '@opentiny/next-sdk'
@@ -169,9 +169,7 @@ if (sessionId) {
 }
 ```
 
-`Web Agent` 服务向外提供的是一个标准的`Mcp Server`，通过`sessionId` 实现在AI 智能体上来遥控网页。
-
-比如：
+`WebAgent` 服务向外提供的是一个标准的`Mcp Server`，通过`sessionId` 实现在AI 智能体上来遥控网页。比如：
 
 - 对接TinyRemoter对话组件
 - 对接遥控网站

--- a/docs/remoter/basic.md
+++ b/docs/remoter/basic.md
@@ -52,8 +52,8 @@ import '@opentiny/next-remoter/dist/style.css'
 ### 1.2 远程遥控模式属性
 
 - `AILogoUrl` 悬浮 AI 图标的 URL 地址
-- `agentRoot` 后端 `Web Agent` 代理服务地址
-- `sessionId` 应用向 `Web Agent` 注册后生成的 ID，用于标识当前页面；若不使用远程遥控模式，可忽略该值
+- `agentRoot` 后端 `WebAgent` 代理服务地址
+- `sessionId` 应用向 `WebAgent` 注册后生成的 ID，用于标识当前页面；若不使用远程遥控模式，可忽略该值
 - `remoteUrl` 远程遥控页面 URL；在遥控器模式下点击「遥控器链接」菜单时跳转至该地址
 - `qrCodeUrl` 远程遥控页面 URL；在遥控器模式下点击「扫码登录」菜单时弹出二维码，扫码成功后进入该地址
 - `menuItems` 菜单项配置数组，用于遥控器模式下点击图标后展示的菜单项，具体配置见 [createRemoter 函数](../webmcp-sdk/create-remoter)。默认显示全部菜单，传入空数组则不显示菜单

--- a/docs/remoter/remoter-mode.md
+++ b/docs/remoter/remoter-mode.md
@@ -8,7 +8,7 @@ outline: [2, 3]
 
 ![remoter.png](../guide/remoter.png)
 
-在 [WebMCP 的适配场景](../guide/choose-scene.md) 中已经详细介绍过远程模式的原理。普通场景下，网站应用可能不需要远程遥控功能，只需在页面中使用原生 WebMCP 编写工具，直接供页面上的 Remoter 组件对话即可。此时无需引入 `Web Agent` 服务，参考 [快速开始](../index) 实现纯前端方案。
+在 [WebMCP 的适配场景](../guide/choose-scene.md) 中已经详细介绍过远程模式的原理。普通场景下，网站应用可能不需要远程遥控功能，只需在页面中使用原生 WebMCP 编写工具，直接供页面上的 Remoter 组件对话即可。此时无需引入 `WebAgent` 服务，参考 [快速开始](../index) 实现纯前端方案。
 
 遥控模式的典型应用场景：
 
@@ -16,11 +16,11 @@ outline: [2, 3]
 2. 连接到其他智能体操作网页，例如 VS Code、CodeX、OpenCode 等
 3. 类似 Chrome DevTools MCP、Browser Use 等工具的用途，支持 AI 操作网页、自动化测试等
 
-## 二、私有化部署 Web Agent 服务
+## 二、私有化部署 WebAgent 服务
 
-部署方法详见 [Web Agent 文档](https://docs.opentiny.design/web-agent/guide/getting-started) 或 [Web Agent 仓库](https://github.com/opentiny/web-agent/blob/main/README.zh-CN.md)。
+部署方法详见 [WebAgent 文档](https://docs.opentiny.design/web-agent/guide/getting-started) 或 [WebAgent 仓库](https://github.com/opentiny/web-agent/blob/main/README.zh-CN.md)。
 
-它本质是一个 Node.js 服务，本地启动后提供一组 API 接口（如 ping、list、mcp 等）。在 `TinyRemoter` 的 `agentRoot` 属性中配置 Web Agent 代理服务地址即可，例如：`http://localhost:3000/api/v1/webmcp/`。
+它本质是一个 Node.js 服务，本地启动后提供一组 API 接口（如 ping、list、mcp 等）。在 `TinyRemoter` 的 `agentRoot` 属性中配置 WebAgent 代理服务地址即可，例如：`http://localhost:3000/api/v1/webmcp/`。
 
 ```vue
 <template>

--- a/docs/webmcp-sdk/webmcp-client.md
+++ b/docs/webmcp-sdk/webmcp-client.md
@@ -54,11 +54,11 @@ const client = new WebMcpClient({ name: 'my-app-client', version: '1.0.0' }, { c
    传入 `WebMcpServer` 的配置信息。内部会自动辅助创建对应的 `Transport` 对象并完成连接。这是直连 `Transport` 对象的简化写法，免去了用户手动 `new Transport()` 的步骤。
 
 3. **代理模式**
-   传入 `WebMcpServer` 的配置信息并启用代理。这是 `WebMcpClient` 的核心创新功能，允许将当前连接的 `WebMcpServer` 端代理至 `Web Agent` 服务器。
+   传入 `WebMcpServer` 的配置信息并启用代理。这是 `WebMcpClient` 的核心创新功能，允许将当前连接的 `WebMcpServer` 端代理至 `WebAgent` 服务器。
 
-   代理成功后，当前的 `WebMcpServer` 网页将变为受控端，并作为一个标准的 `MCP Server` 部署在 `Web Agent` 服务上，供其他 `MCP Client` 进行远程连接和操控。
+   代理成功后，当前的 `WebMcpServer` 网页将变为受控端，并作为一个标准的 `MCP Server` 部署在 `WebAgent` 服务上，供其他 `MCP Client` 进行远程连接和操控。
 
-   如果同时开启了 `builtin: true`，则会自动建立原生的 JSON-RPC 拦截层，将部分 MCP 请求（如 `tools/list`, `tools/call`）拦截并分发给所在浏览器的 `document.modelContext` 原生上下文执行。这样可以让浏览器内置的能力（通过扩展或原生支持）直接透传给 Web Agent。
+   如果同时开启了 `builtin: true`，则会自动建立原生的 JSON-RPC 拦截层，将部分 MCP 请求（如 `tools/list`, `tools/call`）拦截并分发给所在浏览器的 `document.modelContext` 原生上下文执行。这样可以让浏览器内置的能力（通过扩展或原生支持）直接透传给 WebAgent。
 
 **类型声明**
 
@@ -71,7 +71,7 @@ interface ClientConnectOptions {
   builtin?: boolean
   /** Transport类型。*/
   type?: 'channel' | 'sse' | 'stream' | 'socket'
-  /** 代理模式时，传入 Web Agent 服务地址。
+  /** 代理模式时，传入 WebAgent 服务地址。
     非代理模式时，传入 MCP Server的url 地址。 */
   url: string
   /** 令牌*/
@@ -94,7 +94,7 @@ async connect(options: Transport | ClientConnectOptions):
 > - `'stream'`：创建 `StreamableHTTPClientTransport` 以支持 httpstreamable MCP Server 通信。
 > - `'socket'`：创建 `WebSocketClientTransport` 以支持 Web-socket MCP Server 通信。
 >
-> 代理模式时，`type`仅支持 `'sse'` | `'stream'` | `'socket'` 选项，同时需要 `Web Agent` 服务端支持。
+> 代理模式时，`type`仅支持 `'sse'` | `'stream'` | `'socket'` 选项，同时需要 `WebAgent` 服务端支持。
 
 **返回值**
 


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)

> 以下标题与勾选格式供 CI（PR Gate）解析，**请勿改章节标题文案**。
fix: 修改一些拼写错误
## PR Type

What kind of change does this PR introduce?（有且仅有一个 `[x]`）

- [ x ] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [x] Documentation-related changes
- [ ] Other

## PR Checklist

- [ ] Commit / PR 标题符合 `type(scope): subject`（见 CONTRIBUTING）
- [ ] 已按类型填写下方 Gate Fields
- [ ] Bug fix：已补充中文复现测试（`复现：`）
- [ ] Feature：已关联包内 Spec（`packages/<pkg>/specs/REQ-.../`）
- [x] Docs 已按需更新
- [ ] Refactoring：无行为变更或已补回归 / 已填 Skip reason
- [ ] Other：已在说明中写清原因

## Gate Fields（CI 读取，请按类型填写）

- Issue: 
- Spec: 
- Repro test: 
- Skip reason: 

（Bug fix 必填 Repro test；Issue 可选。Feature 必填 Spec；豁免时填 Skip reason。）

## What is the current behavior?

Issue Number: 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized “WebAgent” terminology across remote-control, SDK, and deployment guides.
  * Clarified that WebAgent provides a standard MCP Server, with refined remote-control and connection examples.
  * Updated descriptions for remote registration, session identification, and proxy mode.
  * Corrected WebMCP branding and terminology, including FAQ wording and release-timing guidance.
  * Added/strengthened guidance on the future recommendation to favor the “WebMCP API” and limit “WebMCP Server” usage accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->