### PR TITLE
fix: 修复插件聊天结束后无法关闭page-agent-tool高亮问题

### DIFF
--- a/packages/next-sdk/index.ts
+++ b/packages/next-sdk/index.ts
@@ -54,7 +54,11 @@ export { waitForRouteTools } from './page-tools/wait-for-route-tools'
 export type { RouteToolsMap, WaitForRouteToolsOptions } from './page-tools/wait-for-route-tools'
 export { registerPageAgentTool } from './page-tools/page-agent-tool'
 export type { PageAgentToolHandle } from './page-tools/page-agent-tool'
-export { PAGE_AGENT_TOOL_CALL_EVENT, PAGE_AGENT_TOOL_RESULT_EVENT } from './page-tools/page-agent-tool-event'
+export {
+  PAGE_AGENT_TOOL_CALL_EVENT,
+  PAGE_AGENT_TOOL_RESULT_EVENT,
+  PAGE_AGENT_CHAT_END_EVENT
+} from './page-tools/page-agent-tool-event'
 export type { PageAgentToolCallEventDetail, PageAgentToolResultEventDetail } from './page-tools/page-agent-tool-event'
 export type { PageAgentToolOptions } from './page-tools/tool-config'
 

--- a/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
+++ b/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
@@ -16,6 +16,7 @@ vi.mock('../../page-tools/page-agent-mask/SimulatorMask', () => ({
 }))
 
 import { registerPageAgentTool } from '../../page-tools/page-agent-tool'
+import { PAGE_AGENT_CHAT_END_EVENT } from '../../page-tools/page-agent-tool-event'
 import { getPageAgentToolConfig, setPageAgentToolConfig } from '../../page-tools/tool-config'
 
 function resetWindowGlobals() {
@@ -33,6 +34,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  window.__nextSdkPageAgentToolEventCleanup?.()
   resetWindowGlobals()
 })
 
@@ -126,5 +128,17 @@ describe('registerPageAgentTool - mask 显隐句柄', () => {
 
     await handle.hideMask()
     expect(maskSpies.hide).toHaveBeenCalledTimes(1)
+  })
+
+  it('复现：WXT 聊天结束后呼吸灯与箭头未关闭 —— 前置 registerPageAgentTool 且已 showMask；步骤 dispatch page-agent-chat-end；期望 hideMask 被调用', async () => {
+    const handle = registerPageAgentTool()
+    await handle.showMask()
+    maskSpies.hide.mockClear()
+
+    window.dispatchEvent(new CustomEvent(PAGE_AGENT_CHAT_END_EVENT))
+
+    await vi.waitFor(() => {
+      expect(maskSpies.hide).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/packages/next-wxt/entrypoints/sidepanel/App.vue
+++ b/packages/next-wxt/entrypoints/sidepanel/App.vue
@@ -12,6 +12,7 @@ import { getModelConfigsWithToken } from './model-manage'
 import { getStorageItem, setStorageItem } from './utils/local-storage'
 import { StorageKeys } from './utils/storage-keys'
 import { getSnapshotManager } from './utils/snapshotManager'
+import { dispatchPageAgentChatEnd } from './utils/dispatchPageAgentChatEnd'
 import { getWebAgentUrl } from './model-manage/model-storage'
 // 从统一入口读取 skills（built-in + 用户在 Options 中的覆盖）
 const skills = ref<Record<string, string>>({})
@@ -96,13 +97,18 @@ browser.runtime.onMessage.addListener((message) => {
   }
 })
 
-// 每一轮对话，都要清除一下页面高亮
-const clearHighlightPage = async () => {
+// 每一轮对话结束：清除 snapshot 高亮，并派发 page-agent-chat-end 收起呼吸灯/箭头
+const onChatStreamFinish = async () => {
   try {
     const { manager } = await getSnapshotManager()
     await manager.highlightPage(false)
   } catch (error) {
     console.error('清除页面高亮失败', error)
+  }
+  try {
+    await dispatchPageAgentChatEnd()
+  } catch (error) {
+    console.error('派发 page-agent-chat-end 失败', error)
   }
 }
 </script>
@@ -123,7 +129,7 @@ const clearHighlightPage = async () => {
       :custom-market-mcp-servers="customMarketMcpServers"
       :gen-ui-components="genUiComponents"
       :skills="skills"
-      @chat-stream-finish="clearHighlightPage"
+      @chat-stream-finish="onChatStreamFinish"
       :agent-root="webAgentUrl"
     >
     </TinyRemoter>

--- a/packages/next-wxt/entrypoints/sidepanel/utils/dispatchPageAgentChatEnd.ts
+++ b/packages/next-wxt/entrypoints/sidepanel/utils/dispatchPageAgentChatEnd.ts
@@ -1,0 +1,22 @@
+import { getCurrentTabId } from './utils'
+
+/**
+ * 与 `@opentiny/next-sdk` 的 `PAGE_AGENT_CHAT_END_EVENT` 对齐。
+ * 页面 MAIN world 的 page-agent-tool 监听此事件并调用 hideMask（收起呼吸灯与箭头）。
+ */
+export const PAGE_AGENT_CHAT_END_EVENT = 'page-agent-chat-end'
+
+/**
+ * 向当前（或指定）标签页 MAIN world 派发聊天结束事件，收起 page-agent-tool 的 mask/箭头。
+ */
+export async function dispatchPageAgentChatEnd(tabId?: number): Promise<void> {
+  const id = tabId ?? (await getCurrentTabId())
+  await browser.scripting.executeScript({
+    target: { tabId: id },
+    world: 'MAIN',
+    func: (eventName: string) => {
+      window.dispatchEvent(new CustomEvent(eventName))
+    },
+    args: [PAGE_AGENT_CHAT_END_EVENT]
+  })
+}


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)

> 以下标题与勾选格式供 CI（PR Gate）解析，**请勿改章节标题文案**。

## PR Type

What kind of change does this PR introduce?（有且仅有一个 `[x]`）

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation-related changes
- [ ] Other

## PR Checklist

- [ ] Commit / PR 标题符合 `type(scope): subject`（见 CONTRIBUTING）
- [ ] 已按类型填写下方 Gate Fields
- [x] Bug fix：已补充中文复现测试（`复现：`）
- [ ] Feature：已关联包内 Spec（`packages/<pkg>/specs/REQ-.../`）
- [ ] Docs 已按需更新
- [ ] Refactoring：无行为变更或已补回归 / 已填 Skip reason
- [ ] Other：已在说明中写清原因

## Gate Fields（CI 读取，请按类型填写）

- Issue: 
- Spec: 
- Repro test:  packages/next-sdk/test/page-tools/page-agent-tool.test.ts
- Skip reason: 

（Bug fix 必填 Repro test；Issue 可选。Feature 必填 Spec；豁免时填 Skip reason。）

## What is the current behavior?

Issue Number: 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat completion now reliably hides page-agent masks, arrows, and other visual indicators.
  * Snapshot page highlighting is cleared when chat streaming finishes.
  * Improved cleanup between page-agent interactions to prevent stale UI state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->