### PR TITLE
ci: 优化ci门禁拦截逻辑，不用手动填写，根据文件变更自动读取

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,44 +1,19 @@
 # Pull Request (OpenTiny NEXT-SDKs)
 
-> 以下标题与勾选格式供 CI（PR Gate）解析，**请勿改章节标题文案**。
+> PR Gate 根据**约定式标题**判断类型（`fix` / `feat` / `docs` / …），并从本 PR **变更文件**自动校验复现测试或 Spec。  
+> 标签为兜底（与 auto-label 一致：`bug` / `enhancement` 等）。琐碎 Feature 可打 `skip-spec`；应急打 `gate-bypass`。
 
-## PR Type
+## Summary
 
-What kind of change does this PR introduce?（有且仅有一个 `[x]`）
-
-- [ ] Bug fix
-- [ ] Feature
-- [ ] Code style update (formatting, local variables)
-- [ ] Refactoring (no functional changes, no api changes)
-- [ ] Build-related changes
-- [ ] CI-related changes
-- [ ] Documentation-related changes
-- [ ] Other
-
-## PR Checklist
-
-- [ ] Commit / PR 标题符合 `type(scope): subject`（见 CONTRIBUTING）
-- [ ] 已按类型填写下方 Gate Fields
-- [ ] Bug fix：已补充中文复现测试（`复现：`）
-- [ ] Feature：已关联包内 Spec（`packages/<pkg>/specs/REQ-.../`）
-- [ ] Docs 已按需更新
-- [ ] Refactoring：无行为变更或已补回归 / 已填 Skip reason
-- [ ] Other：已在说明中写清原因
-
-## Gate Fields（CI 读取，请按类型填写）
-
-- Issue: 
-- Spec: 
-- Repro test: 
-- Skip reason: 
-
-（Bug fix 必填 Repro test；Issue 可选。Feature 必填 Spec；豁免时填 Skip reason。）
+-
 
 ## What is the current behavior?
 
-Issue Number: 
+-
 
 ## What is the new behavior?
+
+-
 
 ## Does this PR introduce a breaking change?
 
@@ -46,3 +21,5 @@ Issue Number:
 - [ ] No
 
 ## Other information
+
+（可选。Issue 请用 GitHub 原生关联，无需手填路径。）

--- a/.github/scripts/lib/pr-gate-artifacts.mjs
+++ b/.github/scripts/lib/pr-gate-artifacts.mjs
@@ -1,0 +1,212 @@
+/**
+ * PR Gate：类型推断 + 从变更文件收集 Repro / Spec 候选。
+ * 供 `.github/scripts/pr-gate.mjs` 与单测共用。
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+export const REPRO_RE = /^packages\/[^/]+\/test\/.+\.(test|spec)\.(ts|js|tsx|jsx)$/
+export const SPEC_DIR_RE = /^(packages\/[^/]+\/specs\/REQ-[^/]+)/
+
+/** 约定式标题 type → 门禁 prType */
+export const TITLE_TYPE_TO_PR_TYPE = {
+  fix: 'bug',
+  feat: 'feature',
+  docs: 'docs',
+  doc: 'docs',
+  refactor: 'refactor',
+  style: 'style',
+  build: 'build',
+  ci: 'ci',
+  chore: 'other',
+  test: 'other',
+  perf: 'other',
+  revert: 'other',
+  release: 'other',
+  improvement: 'other'
+}
+
+/** GitHub label（与 labeler.yaml 对齐）→ 门禁 prType */
+export const LABEL_TO_PR_TYPE = {
+  bug: 'bug',
+  enhancement: 'feature',
+  documentation: 'docs',
+  refactoring: 'refactor',
+  chore: 'other'
+}
+
+/**
+ * @param {string} title
+ * @returns {string | null} conventional commit type（小写）
+ */
+export function parseConventionalTitleType(title) {
+  const m = String(title || '')
+    .trim()
+    .match(
+      /^(build|chore|ci|docs?|feat|fix|perf|refactor|revert|release|style|test|improvement)(\([a-z0-9/_.,-]+\))?!?:\s+\S+/i
+    )
+  if (!m) return null
+  const t = m[1].toLowerCase()
+  return t === 'doc' ? 'docs' : t
+}
+
+/**
+ * 标题优先，标签兜底。
+ * @param {string} title
+ * @param {string[]} labels
+ * @returns {{ prType: string | null, source: 'title' | 'label' | null, titleType: string | null, labelType: string | null, conflict: boolean }}
+ */
+export function inferPrType(title, labels = []) {
+  const titleType = parseConventionalTitleType(title)
+  const fromTitle = titleType ? TITLE_TYPE_TO_PR_TYPE[titleType] || 'other' : null
+
+  let fromLabel = null
+  for (const raw of labels) {
+    const key = String(raw || '')
+      .trim()
+      .toLowerCase()
+    if (LABEL_TO_PR_TYPE[key]) {
+      fromLabel = LABEL_TO_PR_TYPE[key]
+      break
+    }
+  }
+
+  if (fromTitle) {
+    return {
+      prType: fromTitle,
+      source: 'title',
+      titleType,
+      labelType: fromLabel,
+      conflict: Boolean(fromLabel && fromLabel !== fromTitle)
+    }
+  }
+  if (fromLabel) {
+    return {
+      prType: fromLabel,
+      source: 'label',
+      titleType: null,
+      labelType: fromLabel,
+      conflict: false
+    }
+  }
+  return { prType: null, source: null, titleType: null, labelType: null, conflict: false }
+}
+
+/**
+ * @param {string[]} changedFiles repo-relative paths
+ * @param {{ root: string, readFileSync?: typeof fs.readFileSync, existsSync?: typeof fs.existsSync }} opts
+ * @returns {string[]}
+ */
+export function collectReproCandidates(changedFiles, opts) {
+  const root = opts.root
+  const readFileSync = opts.readFileSync || fs.readFileSync
+  const existsSync = opts.existsSync || fs.existsSync
+  const out = []
+  const seen = new Set()
+
+  for (const raw of changedFiles) {
+    const file = normalizeRepoPath(raw)
+    if (!file || !REPRO_RE.test(file) || seen.has(file)) continue
+    seen.add(file)
+    const abs = path.join(root, file)
+    if (!existsSync(abs)) continue
+    let content = ''
+    try {
+      content = readFileSync(abs, 'utf8')
+    } catch {
+      continue
+    }
+    if (content.includes('复现：')) out.push(file)
+  }
+  return out
+}
+
+/**
+ * @param {string[]} changedFiles
+ * @param {{ root: string, existsSync?: typeof fs.existsSync }} opts
+ * @returns {string[]} Spec 目录（无尾斜杠）
+ */
+export function collectSpecCandidates(changedFiles, opts) {
+  const root = opts.root
+  const existsSync = opts.existsSync || fs.existsSync
+  const dirs = new Set()
+
+  for (const raw of changedFiles) {
+    const file = normalizeRepoPath(raw)
+    if (!file) continue
+    const m = file.match(SPEC_DIR_RE)
+    if (!m) continue
+    dirs.add(m[1])
+  }
+
+  const out = []
+  for (const dir of dirs) {
+    const abs = path.join(root, dir)
+    const ok = ['requirements.md', 'design.md', 'tasks.md'].every((f) =>
+      existsSync(path.join(abs, f))
+    )
+    if (ok) out.push(dir)
+  }
+  return out.sort()
+}
+
+/**
+ * @param {{ candidates: string[], kind: 'Repro test' | 'Spec' }} args
+ * @returns {{ value: string } | { error: string }}
+ */
+export function resolveArtifact({ candidates, kind }) {
+  if (candidates.length === 1) {
+    return { value: candidates[0] }
+  }
+  if (candidates.length > 1) {
+    return {
+      error:
+        `${kind}：本 PR 变更中有多个候选，请只保留本次相关的一个，或打 label gate-bypass：\n` +
+        candidates.map((c) => `  - ${c}`).join('\n')
+    }
+  }
+  return {
+    error:
+      kind === 'Repro test'
+        ? 'Bug fix（fix:）须在本 PR 变更中包含唯一含中文「复现：」的测试文件：packages/<pkg>/test/**/*.test.ts'
+        : 'Feature（feat:）须在本 PR 变更中包含唯一完整 Spec 目录：packages/<pkg>/specs/REQ-*/（含 requirements/design/tasks）；琐碎改动可打 label skip-spec'
+  }
+}
+
+/** @deprecated 使用 resolveArtifact；保留别名以免旧调用方瞬时断裂 */
+export function resolveArtifactField({ explicit, candidates, kind }) {
+  if (explicit) return { value: explicit, inferred: false }
+  const r = resolveArtifact({ candidates, kind })
+  if ('error' in r) return r
+  return { value: r.value, inferred: true }
+}
+
+export function normalizeRepoPath(p) {
+  if (!p) return ''
+  return String(p).trim().replace(/^\.\//, '').replace(/\\/g, '/')
+}
+
+/**
+ * @param {string} filePath
+ * @returns {string[]}
+ */
+export function readChangedFilesList(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) return []
+  return fs
+    .readFileSync(filePath, 'utf8')
+    .split(/\r?\n/)
+    .map((l) => normalizeRepoPath(l))
+    .filter(Boolean)
+}
+
+/**
+ * @param {string} raw comma/空白分隔
+ * @returns {string[]}
+ */
+export function parseLabels(raw) {
+  if (!raw) return []
+  return String(raw)
+    .split(/[,:\n]/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+}

--- a/.github/scripts/lib/pr-gate-artifacts.mjs
+++ b/.github/scripts/lib/pr-gate-artifacts.mjs
@@ -35,6 +35,8 @@ export const LABEL_TO_PR_TYPE = {
   chore: 'other'
 }
 
+export const EXEMPT_LABELS = Object.freeze(['gate-bypass', 'emergency', 'skip-spec'])
+
 /**
  * @param {string} title
  * @returns {string | null} conventional commit type（小写）
@@ -51,45 +53,100 @@ export function parseConventionalTitleType(title) {
 }
 
 /**
- * 标题优先，标签兜底。
- * @param {string} title
+ * 从标签列表收集已识别的 prType（去重，保持首次出现顺序）。
  * @param {string[]} labels
- * @returns {{ prType: string | null, source: 'title' | 'label' | null, titleType: string | null, labelType: string | null, conflict: boolean }}
+ * @returns {string[]}
  */
-export function inferPrType(title, labels = []) {
-  const titleType = parseConventionalTitleType(title)
-  const fromTitle = titleType ? TITLE_TYPE_TO_PR_TYPE[titleType] || 'other' : null
-
-  let fromLabel = null
+export function collectLabelPrTypes(labels = []) {
+  const out = []
+  const seen = new Set()
   for (const raw of labels) {
     const key = String(raw || '')
       .trim()
       .toLowerCase()
-    if (LABEL_TO_PR_TYPE[key]) {
-      fromLabel = LABEL_TO_PR_TYPE[key]
-      break
-    }
+    const t = LABEL_TO_PR_TYPE[key]
+    if (!t || seen.has(t)) continue
+    seen.add(t)
+    out.push(t)
   }
+  return out
+}
+
+/**
+ * 标题优先，标签兜底。无标题且多标签类型冲突时 prType=null 且 labelConflict=true。
+ * @param {string} title
+ * @param {string[]} labels
+ * @returns {{
+ *   prType: string | null,
+ *   source: 'title' | 'label' | null,
+ *   titleType: string | null,
+ *   labelType: string | null,
+ *   labelTypes: string[],
+ *   conflict: boolean,
+ *   labelConflict: boolean
+ * }}
+ */
+export function inferPrType(title, labels = []) {
+  const titleType = parseConventionalTitleType(title)
+  const fromTitle = titleType ? TITLE_TYPE_TO_PR_TYPE[titleType] || 'other' : null
+  const labelTypes = collectLabelPrTypes(labels)
+  const fromLabel = labelTypes.length === 1 ? labelTypes[0] : null
 
   if (fromTitle) {
     return {
       prType: fromTitle,
       source: 'title',
       titleType,
-      labelType: fromLabel,
-      conflict: Boolean(fromLabel && fromLabel !== fromTitle)
+      labelType: fromLabel || labelTypes[0] || null,
+      labelTypes,
+      conflict: Boolean(labelTypes.length && !labelTypes.every((t) => t === fromTitle)),
+      labelConflict: false
     }
   }
+
+  if (labelTypes.length > 1) {
+    return {
+      prType: null,
+      source: null,
+      titleType: null,
+      labelType: null,
+      labelTypes,
+      conflict: true,
+      labelConflict: true
+    }
+  }
+
   if (fromLabel) {
     return {
       prType: fromLabel,
       source: 'label',
       titleType: null,
       labelType: fromLabel,
-      conflict: false
+      labelTypes,
+      conflict: false,
+      labelConflict: false
     }
   }
-  return { prType: null, source: null, titleType: null, labelType: null, conflict: false }
+
+  return {
+    prType: null,
+    source: null,
+    titleType: null,
+    labelType: null,
+    labelTypes,
+    conflict: false,
+    labelConflict: false
+  }
+}
+
+/**
+ * 豁免标签须完整精确匹配（大小写不敏感），避免 `gate-bypass:pending` 误触发。
+ * @param {string[]} labels
+ * @param {string} name
+ */
+export function hasExactLabel(labels, name) {
+  const want = String(name).toLowerCase()
+  return labels.some((l) => String(l).trim().toLowerCase() === want)
 }
 
 /**
@@ -168,7 +225,7 @@ export function resolveArtifact({ candidates, kind }) {
   return {
     error:
       kind === 'Repro test'
-        ? 'Bug fix（fix:）须在本 PR 变更中包含唯一含中文「复现：」的测试文件：packages/<pkg>/test/**/*.test.ts'
+        ? 'Bug fix（fix:）须在本 PR 变更中包含唯一含中文「复现：」的测试文件：packages/<pkg>/test/**/*.{test,spec}.*'
         : 'Feature（feat:）须在本 PR 变更中包含唯一完整 Spec 目录：packages/<pkg>/specs/REQ-*/（含 requirements/design/tasks）；琐碎改动可打 label skip-spec'
   }
 }
@@ -200,13 +257,26 @@ export function readChangedFilesList(filePath) {
 }
 
 /**
- * @param {string} raw comma/空白分隔
+ * 解析标签列表。优先 JSON 数组（workflow 输出）；否则仅按逗号/换行分割（不按冒号切分，避免破坏含 `:` 的 label）。
+ * @param {string} raw
  * @returns {string[]}
  */
 export function parseLabels(raw) {
   if (!raw) return []
-  return String(raw)
-    .split(/[,:\n]/)
-    .map((s) => s.trim())
+  const s = String(raw).trim()
+  if (!s) return []
+  if (s.startsWith('[')) {
+    try {
+      const arr = JSON.parse(s)
+      if (Array.isArray(arr)) {
+        return arr.map((x) => String(x).trim()).filter(Boolean)
+      }
+    } catch {
+      // fall through
+    }
+  }
+  return s
+    .split(/[,\n]/)
+    .map((x) => x.trim())
     .filter(Boolean)
 }

--- a/.github/scripts/pr-gate.mjs
+++ b/.github/scripts/pr-gate.mjs
@@ -4,7 +4,7 @@
  *
  * 用法：
  *   node .github/scripts/pr-gate.mjs --title "fix(next-sdk): x" --changed-files-file ./changed.txt
- *   node .github/scripts/pr-gate.mjs --title "feat: y" --labels "enhancement" --changed-files-file ./changed.txt
+ *   node .github/scripts/pr-gate.mjs --title "feat: y" --labels '["enhancement"]' --changed-files-file ./changed.txt
  *
  * 环境变量：
  *   PR_TITLE / PR_LABELS / PR_DRAFT / GATE_BYPASS / SKIP_SPEC / GITHUB_WORKSPACE
@@ -18,7 +18,8 @@ import {
   resolveArtifact,
   readChangedFilesList,
   inferPrType,
-  parseLabels
+  parseLabels,
+  hasExactLabel
 } from './lib/pr-gate-artifacts.mjs'
 
 const args = process.argv.slice(2)
@@ -31,7 +32,7 @@ function getArg(name) {
 if (args[0] === '--help' || args[0] === '-h') {
   console.log(`Usage:
   node .github/scripts/pr-gate.mjs --title "type(scope): subject" --changed-files-file <path>
-  node .github/scripts/pr-gate.mjs --title "..." --labels "bug,skip-spec" --changed-files-file <path>
+  node .github/scripts/pr-gate.mjs --title "..." --labels '["bug","skip-spec"]' --changed-files-file <path>
 Env: PR_TITLE, PR_LABELS, PR_DRAFT, GATE_BYPASS, SKIP_SPEC, GITHUB_WORKSPACE`)
   process.exit(0)
 }
@@ -43,11 +44,12 @@ const isDraft = process.env.PR_DRAFT === 'true' || process.env.PR_DRAFT === '1'
 const bypass =
   process.env.GATE_BYPASS === 'true' ||
   process.env.GATE_BYPASS === '1' ||
-  labels.some((l) => ['gate-bypass', 'emergency'].includes(l.toLowerCase()))
+  hasExactLabel(labels, 'gate-bypass') ||
+  hasExactLabel(labels, 'emergency')
 const skipSpec =
   process.env.SKIP_SPEC === 'true' ||
   process.env.SKIP_SPEC === '1' ||
-  labels.some((l) => l.toLowerCase() === 'skip-spec')
+  hasExactLabel(labels, 'skip-spec')
 const changedFilesFile = getArg('--changed-files-file')
 const changedFiles = changedFilesFile ? readChangedFilesList(changedFilesFile) : []
 
@@ -64,18 +66,23 @@ function warn(msg) {
 const TITLE_RE =
   /^(build|chore|ci|docs?|feat|fix|perf|refactor|revert|release|style|test|improvement)(\([a-z0-9/_.,-]+\))?!?: .+/i
 
+const titleOk = Boolean(title.trim()) && TITLE_RE.test(title.trim())
 if (!title.trim()) {
   fail('缺少 PR 标题')
-} else if (!TITLE_RE.test(title.trim())) {
-  fail(
-    `PR 标题不符合约定式提交：type(scope): subject（当前: ${JSON.stringify(title)}）`
-  )
 }
 
 const inferred = inferPrType(title, labels)
 const prType = inferred.prType
 
-if (!prType) {
+if (inferred.labelConflict) {
+  fail(
+    `标签类型冲突（${inferred.labelTypes.join(' / ')}），无法兜底推断 PR 类型：请修正约定式标题，或只保留一个类型标签（bug / enhancement / documentation / refactoring）`
+  )
+} else if (!titleOk) {
+  fail(
+    `PR 标题不符合约定式提交：type(scope): subject（当前: ${JSON.stringify(title)}）`
+  )
+} else if (!prType) {
   fail(
     '无法判断 PR 类型：请使用约定式标题（fix/feat/docs/…），或打标签 bug / enhancement / documentation / refactoring'
   )
@@ -85,7 +92,7 @@ if (!prType) {
   )
   if (inferred.conflict) {
     warn(
-      `标题推断为 ${prType}，但标签指向 ${inferred.labelType}；以标题为准`
+      `标题推断为 ${prType}，但标签指向 ${inferred.labelTypes.join(' / ')}；以标题为准`
     )
   }
 }

--- a/.github/scripts/pr-gate.mjs
+++ b/.github/scripts/pr-gate.mjs
@@ -1,19 +1,25 @@
 #!/usr/bin/env node
 /**
- * PR Gate：校验标题、PR Type、Gate Fields、Spec/复现路径等。
+ * PR Gate：约定式标题 +（可选）标签定类型；从变更文件校验 Repro / Spec。
  *
  * 用法：
- *   node .github/scripts/pr-gate.mjs --title "fix(next-sdk): x" --body-file ./pr.md
- *   node .github/scripts/pr-gate.mjs --title "..." --body "..."
- *   PR_TITLE=... PR_BODY=... node .github/scripts/pr-gate.mjs
+ *   node .github/scripts/pr-gate.mjs --title "fix(next-sdk): x" --changed-files-file ./changed.txt
+ *   node .github/scripts/pr-gate.mjs --title "feat: y" --labels "enhancement" --changed-files-file ./changed.txt
  *
  * 环境变量：
- *   PR_DRAFT=true          Draft 时仅警告不失败（默认硬失败）
- *   GATE_BYPASS=true       跳过 Spec/复现 artifact 校验
- *   GITHUB_WORKSPACE       仓库根（默认 cwd）
+ *   PR_TITLE / PR_LABELS / PR_DRAFT / GATE_BYPASS / SKIP_SPEC / GITHUB_WORKSPACE
  */
 import fs from 'node:fs'
 import path from 'node:path'
+import {
+  REPRO_RE,
+  collectReproCandidates,
+  collectSpecCandidates,
+  resolveArtifact,
+  readChangedFilesList,
+  inferPrType,
+  parseLabels
+} from './lib/pr-gate-artifacts.mjs'
 
 const args = process.argv.slice(2)
 function getArg(name) {
@@ -24,20 +30,26 @@ function getArg(name) {
 
 if (args[0] === '--help' || args[0] === '-h') {
   console.log(`Usage:
-  node .github/scripts/pr-gate.mjs --title "type(scope): subject" --body-file <path>
-  node .github/scripts/pr-gate.mjs --title "..." --body "..."
-Env: PR_TITLE, PR_BODY, PR_DRAFT, GATE_BYPASS, GITHUB_WORKSPACE`)
+  node .github/scripts/pr-gate.mjs --title "type(scope): subject" --changed-files-file <path>
+  node .github/scripts/pr-gate.mjs --title "..." --labels "bug,skip-spec" --changed-files-file <path>
+Env: PR_TITLE, PR_LABELS, PR_DRAFT, GATE_BYPASS, SKIP_SPEC, GITHUB_WORKSPACE`)
   process.exit(0)
 }
 
 const root = process.env.GITHUB_WORKSPACE || process.cwd()
 const title = getArg('--title') || process.env.PR_TITLE || ''
-const bodyFile = getArg('--body-file')
-const body = bodyFile
-  ? fs.readFileSync(bodyFile, 'utf8')
-  : getArg('--body') || process.env.PR_BODY || ''
+const labels = parseLabels(getArg('--labels') || process.env.PR_LABELS || '')
 const isDraft = process.env.PR_DRAFT === 'true' || process.env.PR_DRAFT === '1'
-const bypass = process.env.GATE_BYPASS === 'true' || process.env.GATE_BYPASS === '1'
+const bypass =
+  process.env.GATE_BYPASS === 'true' ||
+  process.env.GATE_BYPASS === '1' ||
+  labels.some((l) => ['gate-bypass', 'emergency'].includes(l.toLowerCase()))
+const skipSpec =
+  process.env.SKIP_SPEC === 'true' ||
+  process.env.SKIP_SPEC === '1' ||
+  labels.some((l) => l.toLowerCase() === 'skip-spec')
+const changedFilesFile = getArg('--changed-files-file')
+const changedFiles = changedFilesFile ? readChangedFilesList(changedFilesFile) : []
 
 const errors = []
 const warnings = []
@@ -50,7 +62,7 @@ function warn(msg) {
 }
 
 const TITLE_RE =
-  /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|release|style|test|improvement)(\([a-z0-9/_.,-]+\))?!?: .+/i
+  /^(build|chore|ci|docs?|feat|fix|perf|refactor|revert|release|style|test|improvement)(\([a-z0-9/_.,-]+\))?!?: .+/i
 
 if (!title.trim()) {
   fail('缺少 PR 标题')
@@ -60,55 +72,23 @@ if (!title.trim()) {
   )
 }
 
-const TYPE_LABELS = [
-  ['bug', 'Bug fix'],
-  ['feature', 'Feature'],
-  ['style', 'Code style update (formatting, local variables)'],
-  ['refactor', 'Refactoring (no functional changes, no api changes)'],
-  ['build', 'Build-related changes'],
-  ['ci', 'CI-related changes'],
-  ['docs', 'Documentation-related changes'],
-  ['other', 'Other'],
-]
+const inferred = inferPrType(title, labels)
+const prType = inferred.prType
 
-function isChecked(label) {
-  // - [x] Label  or - [X] Label
-  const re = new RegExp(
-    String.raw`^\s*-\s*\[(?:x|X)\]\s*${label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\s*$`,
-    'm'
+if (!prType) {
+  fail(
+    '无法判断 PR 类型：请使用约定式标题（fix/feat/docs/…），或打标签 bug / enhancement / documentation / refactoring'
   )
-  return re.test(body)
-}
-
-const checkedTypes = TYPE_LABELS.filter(([, label]) => isChecked(label)).map(([id]) => id)
-if (checkedTypes.length === 0) {
-  fail('PR Type 未勾选（须有且仅有一个 - [x]）')
-} else if (checkedTypes.length > 1) {
-  fail(`PR Type 勾选了多个：${checkedTypes.join(', ')}`)
-}
-const prType = checkedTypes[0] || null
-
-function gateField(name) {
-  // 仅在 Gate Fields 章节内解析，避免吃到下一行 `- xxx:`
-  const sectionMatch = body.match(
-    /##\s*Gate Fields[^\n]*\n([\s\S]*?)(?=\n##\s|\n#\s|$)/i
+} else {
+  console.log(
+    `::notice::PR 类型=${prType}（来源=${inferred.source}${inferred.titleType ? `, title=${inferred.titleType}` : ''}${inferred.labelType ? `, label→${inferred.labelType}` : ''}）`
   )
-  const section = sectionMatch ? sectionMatch[1] : body
-  const re = new RegExp(String.raw`^\s*-\s*${name}:\s*(.*?)\s*$`, 'mi')
-  const m = section.match(re)
-  if (!m) return ''
-  const v = m[1].trim()
-  // 防御误匹配或空行粘连
-  if (!v || v.startsWith('- ') || v.startsWith('[')) return ''
-  return v
+  if (inferred.conflict) {
+    warn(
+      `标题推断为 ${prType}，但标签指向 ${inferred.labelType}；以标题为准`
+    )
+  }
 }
-
-const issue = gateField('Issue')
-const spec = gateField('Spec')
-const repro = gateField('Repro test')
-const skipReason = gateField('Skip reason')
-
-const REPRO_RE = /^packages\/[^/]+\/test\/.+\.(test|spec)\.(ts|js|tsx|jsx)$/
 
 function resolveRepoPath(p) {
   if (!p) return null
@@ -117,23 +97,28 @@ function resolveRepoPath(p) {
 }
 
 if (prType === 'bug') {
-  if (issue && !/#\d+/.test(issue)) {
-    fail('若填写 Issue，格式须为 #N（例如 #42）；无 Issue 时可留空')
-  }
   if (bypass) {
     warn('GATE_BYPASS：跳过 Bug 复现 artifact 校验')
-  } else if (!repro) {
-    fail('Bug fix 须填写 Repro test: packages/<pkg>/test/....test.ts')
-  } else if (!REPRO_RE.test(repro.replace(/^\.\//, ''))) {
-    fail(`Repro test 路径格式非法（须在 packages/*/test/ 下的 *.test.ts）：${repro}`)
   } else {
-    const abs = resolveRepoPath(repro)
-    if (!abs || !fs.existsSync(abs)) {
-      fail(`Repro test 文件不存在：${repro}`)
+    const candidates = collectReproCandidates(changedFiles, { root })
+    const resolved = resolveArtifact({ candidates, kind: 'Repro test' })
+    if ('error' in resolved) {
+      fail(resolved.error)
     } else {
-      const content = fs.readFileSync(abs, 'utf8')
-      if (!content.includes('复现：')) {
-        fail(`Repro test 文件须包含中文场景关键字「复现：」：${repro}`)
+      const repro = resolved.value.replace(/^\.\//, '')
+      console.log(`::notice::Repro test: ${repro}`)
+      if (!REPRO_RE.test(repro)) {
+        fail(`Repro test 路径格式非法：${repro}`)
+      } else {
+        const abs = resolveRepoPath(repro)
+        if (!abs || !fs.existsSync(abs)) {
+          fail(`Repro test 文件不存在：${repro}`)
+        } else {
+          const content = fs.readFileSync(abs, 'utf8')
+          if (!content.includes('复现：')) {
+            fail(`Repro test 文件须包含中文场景关键字「复现：」：${repro}`)
+          }
+        }
       }
     }
   }
@@ -142,43 +127,37 @@ if (prType === 'bug') {
 if (prType === 'feature') {
   if (bypass) {
     warn('GATE_BYPASS：跳过 Feature Spec artifact 校验')
-  } else if (skipReason && /琐碎|文案|typo|chore/i.test(skipReason)) {
-    warn(`Feature 使用 Skip reason 豁免 Spec：${skipReason}`)
-  } else if (!spec) {
-    fail('Feature 须填写 Spec: packages/<pkg>/specs/REQ-.../')
+  } else if (skipSpec) {
+    warn('skip-spec：跳过 Feature Spec artifact 校验')
   } else {
-    const normalized = spec.replace(/^\.\//, '').replace(/\/$/, '')
-    if (normalized.startsWith('docs/') || /\/test\/specs\//.test(normalized)) {
-      fail('Spec 路径不得位于 docs/ 或 test/specs/；须为 packages/<pkg>/specs/REQ-*/')
-    } else if (!/^packages\/[^/]+\/specs\/REQ-[^/]+$/.test(normalized)) {
-      fail(`Spec 路径格式非法：${spec}`)
+    const candidates = collectSpecCandidates(changedFiles, { root })
+    const resolved = resolveArtifact({ candidates, kind: 'Spec' })
+    if ('error' in resolved) {
+      fail(resolved.error)
     } else {
-      const dir = resolveRepoPath(normalized)
-      for (const f of ['requirements.md', 'design.md', 'tasks.md']) {
-        if (!fs.existsSync(path.join(dir, f))) {
-          fail(`Spec 缺少文件：${normalized}/${f}`)
+      const spec = resolved.value
+      console.log(`::notice::Spec: ${spec}`)
+      const normalized = spec.replace(/^\.\//, '').replace(/\/$/, '')
+      if (normalized.startsWith('docs/') || /\/test\/specs\//.test(normalized)) {
+        fail('Spec 路径不得位于 docs/ 或 test/specs/；须为 packages/<pkg>/specs/REQ-*/')
+      } else if (!/^packages\/[^/]+\/specs\/REQ-[^/]+$/.test(normalized)) {
+        fail(`Spec 路径格式非法：${spec}`)
+      } else {
+        const dir = resolveRepoPath(normalized)
+        for (const f of ['requirements.md', 'design.md', 'tasks.md']) {
+          if (!fs.existsSync(path.join(dir, f))) {
+            fail(`Spec 缺少文件：${normalized}/${f}`)
+          }
         }
       }
     }
   }
 }
 
-if (prType === 'other') {
-  const otherInfo = body.includes('## Other information')
-    ? body.split('## Other information')[1]?.trim()
-    : ''
-  if (!otherInfo || otherInfo.length < 8) {
-    fail('Other 类型须在 Other information 中写清原因（至少数十字）')
-  }
-}
-
 if (prType === 'refactor' && !bypass) {
-  // 轻量：若标题含 refactor 且 Skip reason 为空，仅提示（完整文件 diff 在 CI 中用 API 增强可选）
-  if (!skipReason) {
-    warn(
-      'Refactoring：若改动了 packages/<pkg> 源码，请确保同包 test/ 有变更，或填写 Skip reason'
-    )
-  }
+  warn(
+    'Refactoring：若改动了 packages/<pkg> 源码，请确保同包 test/ 有变更，或打 label gate-bypass'
+  )
 }
 
 // 输出

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -49,7 +49,8 @@ jobs:
             const skipSpec = labels.includes('skip-spec')
             core.setOutput('bypass', bypass ? 'true' : 'false')
             core.setOutput('skip_spec', skipSpec ? 'true' : 'false')
-            core.setOutput('labels', labels.join(','))
+            // JSON 数组，避免逗号/冒号拆坏含特殊字符的 label
+            core.setOutput('labels', JSON.stringify(labels))
             core.setOutput('title', pr.title || '')
 
       - name: List changed files
@@ -59,13 +60,13 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
-            git diff --name-only --diff-filter=ACMR "$BASE_SHA...$HEAD_SHA" > changed-files.txt || true
+            git diff --name-only --diff-filter=ACMR "$BASE_SHA...$HEAD_SHA" > changed-files.txt
           else
             : > changed-files.txt
           fi
           echo "changed_count=$(wc -l < changed-files.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
           echo "Changed files ($(wc -l < changed-files.txt | tr -d ' ')):"
-          cat changed-files.txt || true
+          cat changed-files.txt
 
       - name: Run pr-gate
         env:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,10 +1,10 @@
-# PR 合入门禁：标题 / Checklist / Gate Fields / Spec·复现路径
+# PR 合入门禁：约定式标题定类型 + 变更文件校验 Spec/复现
 name: PR Gate
 run-name: PR Gate--${{ github.event.pull_request.title || github.ref_name }}
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, edited, ready_for_review]
+    types: [opened, reopened, synchronize, edited, ready_for_review, labeled, unlabeled]
   workflow_dispatch:
 
 concurrency:
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Meta
         id: meta
@@ -38,38 +39,51 @@ jobs:
             if (!pr) {
               core.setOutput('draft', 'false')
               core.setOutput('bypass', 'false')
+              core.setOutput('skip_spec', 'false')
+              core.setOutput('labels', '')
               return
             }
             core.setOutput('draft', pr.draft ? 'true' : 'false')
             const labels = (pr.labels || []).map((l) => l.name)
             const bypass = labels.includes('gate-bypass') || labels.includes('emergency')
+            const skipSpec = labels.includes('skip-spec')
             core.setOutput('bypass', bypass ? 'true' : 'false')
+            core.setOutput('skip_spec', skipSpec ? 'true' : 'false')
+            core.setOutput('labels', labels.join(','))
             core.setOutput('title', pr.title || '')
-            // body may be large; write to file via env in next step using github-script file
-            const fs = require('fs')
-            fs.writeFileSync('pr-body.md', pr.body || '')
+
+      - name: List changed files
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
+            git diff --name-only --diff-filter=ACMR "$BASE_SHA...$HEAD_SHA" > changed-files.txt || true
+          else
+            : > changed-files.txt
+          fi
+          echo "changed_count=$(wc -l < changed-files.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
+          echo "Changed files ($(wc -l < changed-files.txt | tr -d ' ')):"
+          cat changed-files.txt || true
 
       - name: Run pr-gate
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_LABELS: ${{ steps.meta.outputs.labels }}
           PR_DRAFT: ${{ steps.meta.outputs.draft }}
           GATE_BYPASS: ${{ steps.meta.outputs.bypass }}
+          SKIP_SPEC: ${{ steps.meta.outputs.skip_spec }}
         run: |
-          if [ ! -f pr-body.md ]; then
-            # workflow_dispatch 无 PR body
-            echo "## PR Type" > pr-body.md
-            echo "- [x] Documentation-related changes" >> pr-body.md
-            echo "## Gate Fields（CI 读取，请按类型填写）" >> pr-body.md
-            echo "- Issue: " >> pr-body.md
-            echo "- Spec: " >> pr-body.md
-            echo "- Repro test: " >> pr-body.md
-            echo "- Skip reason: " >> pr-body.md
-            export PR_TITLE="${PR_TITLE:-docs(ai-engineering): workflow dispatch}"
+          export PR_TITLE="${PR_TITLE:-docs(ai-engineering): workflow dispatch}"
+          if [ ! -f changed-files.txt ]; then
+            : > changed-files.txt
           fi
-          node .github/scripts/pr-gate.mjs --title "$PR_TITLE" --body-file pr-body.md
+          node .github/scripts/pr-gate.mjs \
+            --title "$PR_TITLE" \
+            --labels "$PR_LABELS" \
+            --changed-files-file changed-files.txt
 
-  # 依赖同 PR 上 CI Test 工作流的结论较复杂；此处用路径提示 + 成功占位，
-  # Merge Ready 在「gate 通过」基础上成立；完整测试仍由 CI Test workflow 作为独立 required check。
   merge-ready:
     name: Merge Ready
     needs: [gate]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,14 +107,14 @@ pnpm dev / pnpm dev:remoter / pnpm dev:wxt / pnpm wiki
 1. 在主责包创建 `packages/<pkg>/specs/REQ-YYYYMMDD-slug/`
 2. 填写 `requirements.md` / `design.md` / `tasks.md`（模板在 `docs/ai-engineering/templates/`）
 3. `tasks.md` 须列出测试任务；实现落在 `test/`
-4. PR Gate Fields 填写 `Spec: packages/<pkg>/specs/REQ-.../`
+4. PR 标题使用 `feat(...):`；变更中须包含该 Spec 目录（门禁自动校验）。琐碎豁免可打 label `skip-spec`
 
-琐碎改动可豁免 Spec，须在 PR / 对用户回复中说明豁免理由。
+琐碎改动可豁免 Spec，须在 PR / 对用户回复中说明豁免理由（或打 `skip-spec`）。
 
 ## 合入门禁
 
-PR 须通过 **Merge Ready**（标题约定 + Checklist + Gate Fields + 测试）。  
-本地：`pnpm pr-gate` 或 `node .github/scripts/pr-gate.mjs`。  
+PR 须通过 **Merge Ready**（约定式标题定类型 + 变更文件含复现测试/Spec + 测试）。  
+本地：`pnpm pr-gate` 或 `node .github/scripts/pr-gate.mjs --help`。  
 说明：`docs/ai-engineering/merge-gate.md`。
 
 ## 知识索引

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,8 @@ The PR description uses a template. Please fill in the relevant information acco
 
 - Summary / behavior change / breaking change
 - Use a conventional title (`fix` / `feat` / `docs` / …); the gate infers type from the title (labels as fallback)
-- Bugfix: include a test with `复现：` in the PR diff; Feature: include a Spec directory (or label `skip-spec` for trivial changes)
+- Bugfix: the PR diff must include a test under `packages/*/test/**/*.{test,spec}.*` whose content contains `复现：`
+- Feature: the PR diff must include a Spec directory `packages/<pkg>/specs/REQ-*/` with `requirements.md`, `design.md`, and `tasks.md` (or label `skip-spec` for trivial changes)
 - Link Issues via GitHub when applicable
 
 ### Local Startup Steps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,10 +63,10 @@ The commit message should be in the form of `type(scope): description`, e.g. `fi
 
 The PR description uses a template. Please fill in the relevant information according to the template, mainly including:
 
-- PR Checklist: Whether the commit message follows the specification, whether tests have been added, whether docs have been updated
-- PR Type: Bugfix / Feature / Code style update / Refactoring / Build / CI / Documentation, etc.
-- Issue Number
-- Does this PR introduce a breaking change?
+- Summary / behavior change / breaking change
+- Use a conventional title (`fix` / `feat` / `docs` / …); the gate infers type from the title (labels as fallback)
+- Bugfix: include a test with `复现：` in the PR diff; Feature: include a Spec directory (or label `skip-spec` for trivial changes)
+- Link Issues via GitHub when applicable
 
 ### Local Startup Steps
 

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -42,12 +42,17 @@
 
 1. **先分流再编码**：Bug → 复现测试；非琐碎 Feature → 先建 Spec；琐碎豁免须写明理由。判定清单见 `AGENTS.md`「必须建 Spec」。
 2. **就近**：Spec 在 `packages/<pkg>/specs/`，测试在 `packages/<pkg>/test/`，二者不要混放。
-3. **Bugfix**：PR 须提供含「复现：」的测试路径；`pnpm test` 通过。关联 `Issue: #N` **可选**（其它途径反馈的 bug 可不填）。
-4. **Feature**：PR Gate Fields 填写 Spec 路径，且目录含 requirements/design/tasks。
+3. **Bugfix**：PR 标题 `fix:`；变更中须含带「复现：」的测试；`pnpm test` 通过。关联 Issue **可选**（其它途径反馈的 bug 可不填）。
+4. **Feature**：PR 标题 `feat:`；变更中须含完整 Spec 目录（requirements/design/tasks）。琐碎改动打 label `skip-spec`。
 5. **Skills**：`pnpm install` 会执行 `skills:sync`；大 Skill 不进 Git。
 6. **合入**：须通过 GitHub Actions **Merge Ready**；维护者需配置 Branch Protection（见 [`docs/ai-engineering/merge-gate.md`](./docs/ai-engineering/merge-gate.md)）。
 
-本地预检：`pnpm pr-gate`（需自行传入 title/body，见脚本 `--help`）。
+本地预检：
+
+```bash
+git diff --name-only origin/dev...HEAD > /tmp/changed.txt
+node .github/scripts/pr-gate.mjs --title "fix(next-sdk): demo" --changed-files-file /tmp/changed.txt
+```
 
 ## 提交 PR
 

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -50,8 +50,16 @@
 本地预检：
 
 ```bash
-git diff --name-only origin/dev...HEAD > /tmp/changed.txt
-node .github/scripts/pr-gate.mjs --title "fix(next-sdk): demo" --changed-files-file /tmp/changed.txt
+git diff --name-only --diff-filter=ACMR origin/dev...HEAD > /tmp/changed.txt
+PR_LABELS='["skip-spec"]' SKIP_SPEC=true node .github/scripts/pr-gate.mjs \
+  --title "feat(next-sdk): trivial typo" \
+  --labels '["skip-spec"]' \
+  --changed-files-file /tmp/changed.txt
+
+# Bug fix 示例
+node .github/scripts/pr-gate.mjs \
+  --title "fix(next-sdk): demo" \
+  --changed-files-file /tmp/changed.txt
 ```
 
 ## 提交 PR

--- a/docs/ai-engineering/merge-gate.md
+++ b/docs/ai-engineering/merge-gate.md
@@ -4,14 +4,26 @@
 
 | 检查 | Workflow | 作用 |
 |---|---|---|
-| PR Gate | `.github/workflows/pr-gate.yml` | 标题约定、Checklist、Gate Fields、Spec/复现路径 |
+| PR Gate | `.github/workflows/pr-gate.yml` | 约定式标题定类型；变更文件校验 Spec / 复现测试 |
 | CI Test | `.github/workflows/ci-test.yml` | 按路径跑单测 / 浏览器 E2E |
 | Merge Ready | `pr-gate.yml` 汇总 job | 建议作为 Branch Protection 必填检查 |
+
+### 类型与 artifact（无需 Gate Fields）
+
+1. **类型**：PR 标题 `type(scope): subject` 优先（`fix`→bug，`feat`→feature，…）；标签兜底（`bug` / `enhancement` / `documentation` / `refactoring`，与 `labeler.yaml` 一致）。
+2. **Bug（fix）**：变更中须有且仅有一个含中文 **`复现：`** 的 `packages/*/test/**/*.{test,spec}.*`。
+3. **Feature（feat）**：变更中须有且仅有一个完整 `packages/*/specs/REQ-*/`（requirements/design/tasks）。琐碎改动打 label **`skip-spec`**。
+4. **豁免**：label **`gate-bypass`** / **`emergency`**（维护者应急）。
+
+多候选时门禁失败并列出路径：请收敛到一个 artifact，或打豁免标签。
 
 本地预检：
 
 ```bash
-node .github/scripts/pr-gate.mjs --title "fix(next-sdk): demo" --body-file /tmp/pr-body.md
+git diff --name-only origin/dev...HEAD > /tmp/changed.txt
+node .github/scripts/pr-gate.mjs \
+  --title "fix(next-sdk): demo" \
+  --changed-files-file /tmp/changed.txt
 ```
 
 ## 维护者必做：Branch Protection
@@ -28,6 +40,7 @@ node .github/scripts/pr-gate.mjs --title "fix(next-sdk): demo" --body-file /tmp/
 ## 豁免
 
 - Label `gate-bypass`：仅维护者应急，跳过 Spec/复现等 artifact 校验；须在 PR 写明原因。  
+- Label `skip-spec`：琐碎 Feature 跳过 Spec。  
 - 不提供「跳过全部测试」的默认开关。
 
 ## Draft PR

--- a/docs/ai-engineering/merge-gate.md
+++ b/docs/ai-engineering/merge-gate.md
@@ -20,9 +20,17 @@
 本地预检：
 
 ```bash
-git diff --name-only origin/dev...HEAD > /tmp/changed.txt
+# 与 CI 一致：只统计 Added/Copied/Modified/Renamed
+git diff --name-only --diff-filter=ACMR origin/dev...HEAD > /tmp/changed.txt
 node .github/scripts/pr-gate.mjs \
   --title "fix(next-sdk): demo" \
+  --labels '[]' \
+  --changed-files-file /tmp/changed.txt
+
+# Feature 琐碎豁免示例
+PR_LABELS='["skip-spec"]' SKIP_SPEC=true node .github/scripts/pr-gate.mjs \
+  --title "feat(docs): typo" \
+  --labels '["skip-spec"]' \
   --changed-files-file /tmp/changed.txt
 ```
 

--- a/docs/ai-engineering/templates/bug-repro.md
+++ b/docs/ai-engineering/templates/bug-repro.md
@@ -33,4 +33,4 @@ it('复现：<中文场景简述> —— 前置…；步骤…；期望…', () 
 })
 ```
 
-PR Gate 对 Bugfix 会检查 `Repro test` 路径及文件中含 `复现：` 关键字。
+PR Gate 对 Bugfix 会检查本 PR **变更文件**中是否含带 `复现：` 关键字的测试（见 `docs/ai-engineering/merge-gate.md`）。

--- a/packages/next-sdk/specs/README.md
+++ b/packages/next-sdk/specs/README.md
@@ -20,6 +20,7 @@
 
 | Spec | 说明 |
 |---|---|
+| [`REQ-20260724-pr-gate-auto-artifact`](./REQ-20260724-pr-gate-auto-artifact/) | PR Gate：标题定类型 + 变更文件自动校验 Repro/Spec |
 | [`REQ-20260722-console-layout-landmark`](./REQ-20260722-console-layout-landmark/) | `A11yRoleRule.name` + 云控制台 ti-app-layout landmark |
 | [`REQ-20260721-remove-set-navigator`](./REQ-20260721-remove-set-navigator/) | 移除 setNavigator / routeConfig |
 
@@ -29,4 +30,4 @@ Spec 是文档；可执行测试在 `../test/`。禁止把 Spec 放进 `test/`�
 
 ## 跨包需求
 
-若改动跨多个包，Spec 放在 **主责包** 的 `specs/`；PR Gate Fields 的 `Spec:` 指向该路径。
+若改动跨多个包，Spec 放在 **主责包** 的 `specs/`；`feat:` PR 的变更中须包含该 Spec 目录（门禁自动校验）。

--- a/packages/next-sdk/specs/REQ-20260724-pr-gate-auto-artifact/design.md
+++ b/packages/next-sdk/specs/REQ-20260724-pr-gate-auto-artifact/design.md
@@ -20,10 +20,14 @@
 
 标题与标签冲突时：**以标题为准**，并对标签冲突打 warning。
 
+**无约定式标题**且标签映射出多个不同 prType 时：返回 `labelConflict`，门禁**失败**（不得按标签顺序择一），须修正标题或移除冲突标签。冲突标签**不得**绕过 Repro/Spec 校验。
+
 ## 豁免
 
-- `gate-bypass` / `emergency`：跳过 artifact
-- `skip-spec`：仅 Feature 跳过 Spec
+- `gate-bypass` / `emergency`：跳过 artifact（须与 label **完整精确匹配**；`gate-bypass:pending` 之类不生效）
+- `skip-spec`：仅 Feature 跳过 Spec（同样精确匹配）
+
+Labels 由 workflow 以 JSON 数组传入，解析时不按冒号切分。
 
 ## 模块影响
 

--- a/packages/next-sdk/specs/REQ-20260724-pr-gate-auto-artifact/design.md
+++ b/packages/next-sdk/specs/REQ-20260724-pr-gate-auto-artifact/design.md
@@ -1,0 +1,36 @@
+# Spec：design.md
+
+## 方案概述
+
+类型推断：`inferPrType(title, labels)` — 先解析约定式标题的 type，再映射 label（与 `.github/labeler.yaml` 对齐）。Artifact：仅 `collectReproCandidates` / `collectSpecCandidates` + `resolveArtifact`（无手填）。模板只保留行为说明与 breaking change。
+
+## 类型映射
+
+| 来源 | → prType |
+|---|---|
+| 标题 `fix` | bug |
+| 标题 `feat` | feature |
+| 标题 `docs` | docs |
+| 标题 `refactor` | refactor |
+| 标题 `ci` / `build` / `style` | ci / build / style |
+| 标题其它约定 type | other（不强制 Spec/Repro） |
+| label `bug` | bug（标题未命中时） |
+| label `enhancement` | feature |
+| label `documentation` / `refactoring` / `chore` | docs / refactor / other |
+
+标题与标签冲突时：**以标题为准**，并对标签冲突打 warning。
+
+## 豁免
+
+- `gate-bypass` / `emergency`：跳过 artifact
+- `skip-spec`：仅 Feature 跳过 Spec
+
+## 模块影响
+
+- `.github/scripts/lib/pr-gate-artifacts.mjs`：新增 `inferPrType`；`resolveArtifact` 去掉 explicit
+- `.github/scripts/pr-gate.mjs`、`pr-gate.yml`、`PULL_REQUEST_TEMPLATE.md`
+- `docs/ai-engineering/merge-gate.md`、`AGENTS.md`、`CONTRIBUTING.zh-CN.md`
+
+## 测试策略
+
+vitest 覆盖 `inferPrType` / `resolveArtifact`；脚本级冒烟用临时 title + changed-files。

--- a/packages/next-sdk/specs/REQ-20260724-pr-gate-auto-artifact/requirements.md
+++ b/packages/next-sdk/specs/REQ-20260724-pr-gate-auto-artifact/requirements.md
@@ -1,0 +1,44 @@
+# Spec：requirements.md
+
+## 元信息
+
+- 状态：已交付
+- 主责包：`packages/next-sdk`（门禁脚本在仓库根 `.github/`）
+- 关联 Issue：无（延续：去掉 Gate Fields 手填，标题/标签定类型）
+
+## 背景
+
+Gate Fields / PR Type 勾选对开发者重复劳动。仓库已有约定式标题与 auto-label（`fix`→`bug`，`feat`→`enhancement`）。门禁应：**标题优先定类型 → 标签兜底 → 仅从变更文件校验 Repro/Spec**，模板不再要求填写 Gate Fields。
+
+## 目标用户 / 场景
+
+- 开 `fix(...):` PR：变更含唯一「复现：」测试即可过门禁，无需勾选/填路径
+- 开 `feat(...):` PR：变更含唯一完整 Spec 即可；琐碎用 label `skip-spec`
+- 多候选：失败并列路径，用收敛变更或 `gate-bypass` 处理
+
+## 范围
+
+### In Scope
+
+- 去掉模板中的 PR Type 勾选与 Gate Fields
+- `pr-gate`：从标题 conventional type 推断；labels 兜底
+- artifact 仅来自 `--changed-files-file`
+- 豁免：`gate-bypass` / `emergency`；Feature 另支持 `skip-spec`
+- 文档与 AGENTS / CONTRIBUTING 同步
+
+### Out of Scope
+
+- 自动改写 PR body
+- 自动创建 Spec / 测试文件
+
+## 用户故事与验收标准
+
+1. `fix:` + 变更唯一含「复现：」测试 → OK，无需 body 勾选
+2. `feat:` + 变更唯一 Spec → OK
+3. `feat:` + label `skip-spec` → 跳过 Spec 校验
+4. 多候选 → fail 并列出路径（不再要求 Gate Fields 手填）
+5. 标题无法识别且无标签 → fail，提示改标题或打标签
+
+## 明确不做
+
+- 不再解析 Gate Fields / PR Type checkbox

--- a/packages/next-sdk/specs/REQ-20260724-pr-gate-auto-artifact/requirements.md
+++ b/packages/next-sdk/specs/REQ-20260724-pr-gate-auto-artifact/requirements.md
@@ -37,7 +37,9 @@ Gate Fields / PR Type 勾选对开发者重复劳动。仓库已有约定式标�
 2. `feat:` + 变更唯一 Spec → OK
 3. `feat:` + label `skip-spec` → 跳过 Spec 校验
 4. 多候选 → fail 并列出路径（不再要求 Gate Fields 手填）
-5. 标题无法识别且无标签 → fail，提示改标题或打标签
+5. 标题无法识别且无唯一标签 → fail，提示改标题或打标签
+6. 无约定式标题且 `bug`+`documentation` 等冲突标签 → fail（任一顺序），不得择一绕过 Repro/Spec
+7. `gate-bypass:pending` 等非精确 label → 不触发豁免
 
 ## 明确不做
 

--- a/packages/next-sdk/specs/REQ-20260724-pr-gate-auto-artifact/tasks.md
+++ b/packages/next-sdk/specs/REQ-20260724-pr-gate-auto-artifact/tasks.md
@@ -1,0 +1,10 @@
+# Spec：tasks.md
+
+## Tasks
+
+- [x] Task 1: artifacts 库（collect / resolve / inferPrType）
+- [x] Task 2: pr-gate 去掉 Gate Fields / checkbox，接入标题+标签
+- [x] Task 3: workflow 传 labels + changed-files
+- [x] Task 4: 精简 PR 模板与文档（merge-gate / AGENTS / CONTRIBUTING）
+- [x] Task 5: 单测 `pr-gate-auto-artifact.test.ts`
+  - 命令：`pnpm -F @opentiny/next-sdk exec vitest run test/page-tools/pr-gate-auto-artifact.test.ts`

--- a/packages/next-sdk/specs/REQ-20260724-pr-gate-auto-artifact/tasks.md
+++ b/packages/next-sdk/specs/REQ-20260724-pr-gate-auto-artifact/tasks.md
@@ -7,4 +7,7 @@
 - [x] Task 3: workflow 传 labels + changed-files
 - [x] Task 4: 精简 PR 模板与文档（merge-gate / AGENTS / CONTRIBUTING）
 - [x] Task 5: 单测 `pr-gate-auto-artifact.test.ts`
-  - 命令：`pnpm -F @opentiny/next-sdk exec vitest run test/page-tools/pr-gate-auto-artifact.test.ts`
+  - 命令：
+    - `pnpm -F @opentiny/next-sdk exec vitest run test/page-tools/pr-gate-auto-artifact.test.ts`
+    - `pnpm -F @opentiny/next-sdk test`
+    - `pnpm -F @opentiny/next-sdk build`

--- a/packages/next-sdk/test/page-tools/pr-gate-auto-artifact.test.ts
+++ b/packages/next-sdk/test/page-tools/pr-gate-auto-artifact.test.ts
@@ -8,7 +8,9 @@ import {
   resolveArtifactField,
   normalizeRepoPath,
   inferPrType,
-  parseConventionalTitleType
+  parseConventionalTitleType,
+  parseLabels,
+  hasExactLabel
 } from '../../../../.github/scripts/lib/pr-gate-artifacts.mjs'
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..')
@@ -19,7 +21,20 @@ describe('pr-gate auto artifact', () => {
     expect(normalizeRepoPath('packages\\foo\\test\\a.test.ts')).toBe('packages/foo/test/a.test.ts')
   })
 
-  it('inferPrType：标题优先，标签兜底，冲突以标题为准', () => {
+  it('parseLabels：JSON 数组无损；逗号分隔不按冒号切开', () => {
+    expect(parseLabels('["bug","skip-spec"]')).toEqual(['bug', 'skip-spec'])
+    expect(parseLabels('bug,skip-spec')).toEqual(['bug', 'skip-spec'])
+    expect(parseLabels('gate-bypass:pending')).toEqual(['gate-bypass:pending'])
+  })
+
+  it('hasExactLabel：含冒号的近似名不触发豁免', () => {
+    expect(hasExactLabel(['gate-bypass'], 'gate-bypass')).toBe(true)
+    expect(hasExactLabel(['gate-bypass:pending'], 'gate-bypass')).toBe(false)
+    expect(hasExactLabel(['skip-spec'], 'skip-spec')).toBe(true)
+    expect(hasExactLabel(['skip-spec:ok'], 'skip-spec')).toBe(false)
+  })
+
+  it('inferPrType：标题优先；无标题时多标签冲突不得择一通过', () => {
     expect(parseConventionalTitleType('fix(next-wxt): hide mask')).toBe('fix')
     expect(inferPrType('fix(next-wxt): hide mask', [])).toMatchObject({
       prType: 'bug',
@@ -34,8 +49,14 @@ describe('pr-gate auto artifact', () => {
       prType: 'feature',
       source: 'label'
     })
-    // 非法标题（无 subject）不作为约定式
-    expect(inferPrType('fix:', ['bug']).source).not.toBe('title')
+
+    const a = inferPrType('invalid title', ['documentation', 'bug'])
+    expect(a).toMatchObject({ prType: null, labelConflict: true })
+    expect(a.labelTypes).toEqual(['docs', 'bug'])
+
+    const b = inferPrType('invalid title', ['bug', 'documentation'])
+    expect(b).toMatchObject({ prType: null, labelConflict: true })
+    expect(b.labelTypes).toEqual(['bug', 'docs'])
   })
 
   it('collectReproCandidates：仅收录含「复现：」且路径合法的测试文件', () => {
@@ -79,7 +100,6 @@ describe('pr-gate auto artifact', () => {
       expect(empty.error).toContain('skip-spec')
     }
 
-    // 兼容旧别名：explicit 仍可用
     expect(
       resolveArtifactField({
         explicit: 'packages/a/test/x.test.ts',

--- a/packages/next-sdk/test/page-tools/pr-gate-auto-artifact.test.ts
+++ b/packages/next-sdk/test/page-tools/pr-gate-auto-artifact.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  collectReproCandidates,
+  collectSpecCandidates,
+  resolveArtifact,
+  resolveArtifactField,
+  normalizeRepoPath,
+  inferPrType,
+  parseConventionalTitleType
+} from '../../../../.github/scripts/lib/pr-gate-artifacts.mjs'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..')
+
+describe('pr-gate auto artifact', () => {
+  it('normalizeRepoPath 去掉 ./ 与反斜杠', () => {
+    expect(normalizeRepoPath('./packages/foo/test/a.test.ts')).toBe('packages/foo/test/a.test.ts')
+    expect(normalizeRepoPath('packages\\foo\\test\\a.test.ts')).toBe('packages/foo/test/a.test.ts')
+  })
+
+  it('inferPrType：标题优先，标签兜底，冲突以标题为准', () => {
+    expect(parseConventionalTitleType('fix(next-wxt): hide mask')).toBe('fix')
+    expect(inferPrType('fix(next-wxt): hide mask', [])).toMatchObject({
+      prType: 'bug',
+      source: 'title'
+    })
+    expect(inferPrType('feat(next-sdk): add landmark', ['bug'])).toMatchObject({
+      prType: 'feature',
+      source: 'title',
+      conflict: true
+    })
+    expect(inferPrType('WIP: something', ['enhancement'])).toMatchObject({
+      prType: 'feature',
+      source: 'label'
+    })
+    // 非法标题（无 subject）不作为约定式
+    expect(inferPrType('fix:', ['bug']).source).not.toBe('title')
+  })
+
+  it('collectReproCandidates：仅收录含「复现：」且路径合法的测试文件', () => {
+    const files = [
+      'packages/next-sdk/test/page-tools/pr-gate-repro.fixture.test.ts',
+      'packages/next-sdk/page-tools/page-agent-tool.ts',
+      'README.md'
+    ]
+    const got = collectReproCandidates(files, { root })
+    expect(got).toEqual(['packages/next-sdk/test/page-tools/pr-gate-repro.fixture.test.ts'])
+  })
+
+  it('collectSpecCandidates：完整 REQ 目录才入选', () => {
+    const files = [
+      'packages/next-sdk/specs/REQ-20260724-pr-gate-auto-artifact/requirements.md',
+      'packages/next-sdk/specs/REQ-20260724-pr-gate-auto-artifact/design.md',
+      'packages/next-sdk/specs/REQ-20260724-pr-gate-auto-artifact/tasks.md'
+    ]
+    const got = collectSpecCandidates(files, { root })
+    expect(got).toEqual(['packages/next-sdk/specs/REQ-20260724-pr-gate-auto-artifact'])
+  })
+
+  it('resolveArtifact：唯一候选通过；多候选/零候选报错（不再依赖 Gate Fields）', () => {
+    expect(resolveArtifact({ candidates: ['packages/a/test/x.test.ts'], kind: 'Repro test' })).toEqual({
+      value: 'packages/a/test/x.test.ts'
+    })
+
+    const multi = resolveArtifact({
+      candidates: ['packages/a/test/x.test.ts', 'packages/b/test/y.test.ts'],
+      kind: 'Repro test'
+    })
+    expect('error' in multi).toBe(true)
+    if ('error' in multi) {
+      expect(multi.error).toContain('多个候选')
+      expect(multi.error).not.toContain('Gate Fields')
+    }
+
+    const empty = resolveArtifact({ candidates: [], kind: 'Spec' })
+    expect('error' in empty).toBe(true)
+    if ('error' in empty) {
+      expect(empty.error).toContain('skip-spec')
+    }
+
+    // 兼容旧别名：explicit 仍可用
+    expect(
+      resolveArtifactField({
+        explicit: 'packages/a/test/x.test.ts',
+        candidates: [],
+        kind: 'Repro test'
+      })
+    ).toEqual({ value: 'packages/a/test/x.test.ts', inferred: false })
+  })
+})


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)

> 以下标题与勾选格式供 CI（PR Gate）解析，**请勿改章节标题文案**。

## PR Type

What kind of change does this PR introduce?（有且仅有一个 `[x]`）

- [ ] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation-related changes
- [ ] Other

## PR Checklist

- [ ] Commit / PR 标题符合 `type(scope): subject`（见 CONTRIBUTING）
- [ ] 已按类型填写下方 Gate Fields
- [ ] Bug fix：已补充中文复现测试（`复现：`）
- [ ] Feature：已关联包内 Spec（`packages/<pkg>/specs/REQ-.../`）
- [ ] Docs 已按需更新
- [ ] Refactoring：无行为变更或已补回归 / 已填 Skip reason
- [ ] Other：已在说明中写清原因

## Gate Fields（CI 读取，请按类型填写）

- Issue: 
- Spec: 
- Repro test: 
- Skip reason: 

（Bug fix 必填 Repro test；Issue 可选。Feature 必填 Spec；豁免时填 Skip reason。）

## What is the current behavior?

Issue Number: 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR validation now gates by inferring change type from the PR title (with label fallback) and validates required artifacts using the PR’s changed files.
  * Feature validation supports `skip-spec`; exceptional cases can be bypassed with `gate-bypass`/`emergency`.
  * Workflow reacts to `labeled`/`unlabeled` updates and reports clearer warnings/errors (including type-source and conflict notices).
* **Documentation**
  * Updated PR templates and contribution/merge-gate docs to reflect title/label-based gating and changed-files-driven checks; added new spec documentation.
* **Tests**
  * Added unit and workflow tests covering type inference, artifact discovery/selection rules, path/label parsing, and validation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->