### PR TITLE
feat: 遮罩层允许用户点击穿透，增加用户操作反馈的事件

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "pub:next-sdk": "pnpm -F @opentiny/next-sdk publish --no-git-checks",
     "pub:remoter": "pnpm -F @opentiny/next-remoter publish --no-git-checks",
     "dev:webmcp-cli": "pnpm -F @opentiny/webmcp-cli dev",
-    "build:webmcp-cli": "pnpm -F @opentiny/webmcp-cli build",
+    "build:webmcp-cli": "pnpm build && pnpm -F @opentiny/webmcp-cli build",
     "pr-gate": "node ./.github/scripts/pr-gate.mjs"
   },
   "devDependencies": {

--- a/packages/next-sdk/index.ts
+++ b/packages/next-sdk/index.ts
@@ -57,21 +57,27 @@ export type { PageAgentToolHandle } from './page-tools/page-agent-tool'
 export {
   PAGE_AGENT_TOOL_CALL_EVENT,
   PAGE_AGENT_TOOL_RESULT_EVENT,
-  PAGE_AGENT_CHAT_END_EVENT
+  PAGE_AGENT_CHAT_END_EVENT,
+  PAGE_AGENT_USER_DO_ACTION_EVENT
 } from './page-tools/page-agent-tool-event'
-export type { PageAgentToolCallEventDetail, PageAgentToolResultEventDetail } from './page-tools/page-agent-tool-event'
+export type {
+  PageAgentToolCallEventDetail,
+  PageAgentToolResultEventDetail,
+  PageAgentUserDoActionEventDetail
+} from './page-tools/page-agent-tool-event'
 export type { PageAgentToolOptions } from './page-tools/tool-config'
 
 // registerPageAgentTool 完整运行期配置（顶层选项 enableHighlight + 统一无障碍配置 a11yConfig）
 // 的唯一一套读写 API：注册时初始化一次，之后可随时读取/修改
-export { DEFAULT_PAGE_AGENT_TOOL_CONFIG, getPageAgentToolConfig, setPageAgentToolConfig } from './page-tools/tool-config'
+export {
+  DEFAULT_PAGE_AGENT_TOOL_CONFIG,
+  getPageAgentToolConfig,
+  setPageAgentToolConfig
+} from './page-tools/tool-config'
 export type { PageAgentToolConfig, PageAgentToolConfigPatch } from './page-tools/tool-config'
 
 // 站点预设：云控制台（consoleCloud）等 PageAgentToolOptions，可直接传给 registerPageAgentTool
-export {
-  consoleCloudPageAgentToolOptions,
-  isConsoleCloudHost,
-} from './page-tools/configs/console-cloud'
+export { consoleCloudPageAgentToolOptions, isConsoleCloudHost } from './page-tools/configs/console-cloud'
 
 // 统一无障碍配置（A11yConfig）：角色/状态规则、白/黑名单、自定义属性、弹窗选择器，
 // 以及供用户直接调用的底层解析函数（运行期读写请使用上面的 getPageAgentToolConfig/setPageAgentToolConfig）
@@ -85,11 +91,25 @@ export {
   mergeA11yConfigs,
   ensureResolvedA11yConfig,
   isResolvedA11yConfig,
-  extractSelectors,
+  extractSelectors
 } from './page-tools/a11y/config'
-export type { A11yConfig, ResolvedA11yConfig, A11yRoleRule, A11yMatcher, A11yStateName, A11yInfo } from './page-tools/a11y/config'
+export type {
+  A11yConfig,
+  ResolvedA11yConfig,
+  A11yRoleRule,
+  A11yMatcher,
+  A11yStateName,
+  A11yInfo
+} from './page-tools/a11y/config'
 
 // 无障碍树构建与搜索：供高级用户直接生成/搜索自定义根节点下的无障碍树
 export { buildA11yTree } from './page-tools/a11y/build'
 export { searchA11yTree } from './page-tools/a11y/search'
-export type { A11yTreeOptions, A11yTreeResult, SearchA11yTreeOptions, SearchA11yTreeResult, VNode, RefMap } from './page-tools/a11y/types'
+export type {
+  A11yTreeOptions,
+  A11yTreeResult,
+  SearchA11yTreeOptions,
+  SearchA11yTreeResult,
+  VNode,
+  RefMap
+} from './page-tools/a11y/types'

--- a/packages/next-sdk/page-tools/page-agent-mask/SimulatorMask.ts
+++ b/packages/next-sdk/page-tools/page-agent-mask/SimulatorMask.ts
@@ -61,9 +61,9 @@ const injectStyles = `
 .webmcp-page-agent-wrapper {
 	position: fixed;
 	inset: 0;
-	z-index: 2147483641;
 	/* 确保在所有元素之上，除了 panel */
-	cursor: wait;
+	z-index: 2147483641;
+	/*cursor: wait;*/
 	overflow: hidden;
 
 	display: none;
@@ -143,7 +143,7 @@ export class SimulatorMask extends EventTarget {
       this.wrapper.style.pointerEvents = 'none'
     }
     const disablePassThroughListener = () => {
-      this.wrapper.style.pointerEvents = 'auto'
+      this.wrapper.style.pointerEvents = 'none' // 不接收鼠标事件，允许透传下去给目标元素
     }
 
     window.addEventListener('PageAgent::MovePointerTo', movePointerToListener)

--- a/packages/next-sdk/page-tools/page-agent-tool-event.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool-event.ts
@@ -1,9 +1,11 @@
+import { ActionContext } from './context'
 import { inputSchema, type PageAgentToolInput, type PageAgentToolRawInput } from './schema'
 import { PageController } from '@page-agent/page-controller'
 
 export const PAGE_AGENT_TOOL_CALL_EVENT = 'page-agent-tool-call'
 export const PAGE_AGENT_TOOL_RESULT_EVENT = 'page-agent-tool-result'
 export const PAGE_AGENT_CHAT_END_EVENT = 'page-agent-chat-end'
+export const PAGE_AGENT_USER_DO_ACTION_EVENT = 'page-agent-user-do-action' // 用户执行click 等操作事件
 
 export type PageAgentToolCallEventDetail = {
   data?: PageAgentToolRawInput
@@ -44,7 +46,8 @@ function dispatchPageAgentToolResult(detail: PageAgentToolResultEventDetail) {
 
 export function setupPageAgentToolEventBridge(
   executePageAgentTool: ExecutePageAgentTool,
-  pageController: PageController
+  pageController: PageController,
+  actionContext: ActionContext
 ) {
   window.__nextSdkPageAgentToolEventCleanup?.()
 
@@ -102,12 +105,28 @@ export function setupPageAgentToolEventBridge(
     } catch (error) {}
   }
 
+  const handleUserDoAction = async (ev: MouseEvent) => {
+    // @ts-ignore
+    if (ev.isTrusted && pageController.mask.shown) {
+      // 通过ev.target找到 refMap 对应的元素
+      const target = ev.target as HTMLElement
+      const refMap = actionContext.getRefMap()
+      const targetParent = Array.from(refMap.values()).find((el) => el.contains(target)) as HTMLElement | undefined
+
+      if (targetParent) {
+        window.dispatchEvent(new CustomEvent(PAGE_AGENT_USER_DO_ACTION_EVENT, { detail }))
+      }
+    }
+  }
+
   window.addEventListener(PAGE_AGENT_TOOL_CALL_EVENT, handleToolCall)
   window.addEventListener(PAGE_AGENT_CHAT_END_EVENT, handleChatEnd)
+  window.addEventListener('click', handleUserDoAction, true)
 
   window.__nextSdkPageAgentToolEventCleanup = () => {
     window.removeEventListener(PAGE_AGENT_TOOL_CALL_EVENT, handleToolCall)
     window.removeEventListener(PAGE_AGENT_CHAT_END_EVENT, handleChatEnd)
+    window.removeEventListener('click', handleUserDoAction, true)
     window.__nextSdkPageAgentToolEventCleanup = undefined
   }
 }

--- a/packages/next-sdk/page-tools/page-agent-tool-event.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool-event.ts
@@ -21,6 +21,13 @@ export type PageAgentToolResultEventDetail = {
   requestId: string
 }
 
+export type PageAgentUserDoActionEventDetail = {
+  /** 当前仅支持 'click'，预留其它用户操作类型 */
+  action: 'click'
+  /** refMap 中命中 ev.target 的根 DOM 元素 */
+  dom: HTMLElement
+}
+
 type ExecutePageAgentTool = (data: PageAgentToolInput) => Promise<unknown>
 
 function isPageAgentToolErrorResult(result: unknown): result is { isError: true; error: string } {
@@ -114,9 +121,11 @@ export function setupPageAgentToolEventBridge(
       const targetParent = Array.from(refMap.values()).find((el) => el.contains(target)) as HTMLElement | undefined
 
       if (targetParent) {
-        window.dispatchEvent(
-          new CustomEvent(PAGE_AGENT_USER_DO_ACTION_EVENT, { detail: { action: 'click', dom: targetParent } })
-        )
+        const detail: PageAgentUserDoActionEventDetail = {
+          action: 'click',
+          dom: targetParent
+        }
+        window.dispatchEvent(new CustomEvent(PAGE_AGENT_USER_DO_ACTION_EVENT, { detail }))
       }
     }
   }

--- a/packages/next-sdk/page-tools/page-agent-tool-event.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool-event.ts
@@ -114,7 +114,9 @@ export function setupPageAgentToolEventBridge(
       const targetParent = Array.from(refMap.values()).find((el) => el.contains(target)) as HTMLElement | undefined
 
       if (targetParent) {
-        window.dispatchEvent(new CustomEvent(PAGE_AGENT_USER_DO_ACTION_EVENT, { detail }))
+        window.dispatchEvent(
+          new CustomEvent(PAGE_AGENT_USER_DO_ACTION_EVENT, { detail: { action: 'click', dom: targetParent } })
+        )
       }
     }
   }

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -242,7 +242,7 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
     }
   })
 
-  setupPageAgentToolEventBridge(executePageAgentTool, pageController)
+  setupPageAgentToolEventBridge(executePageAgentTool, pageController, actionContext)
 
   return {
     showMask: () => pageController.showMask(),

--- a/packages/next-sdk/specs/README.md
+++ b/packages/next-sdk/specs/README.md
@@ -20,7 +20,9 @@
 
 | Spec | 说明 |
 |---|---|
+| [`REQ-20260729-user-do-action`](./REQ-20260729-user-do-action/) | mask 展示期间用户 trusted 点击 → `page-agent-user-do-action` 事件 |
 | [`REQ-20260724-pr-gate-auto-artifact`](./REQ-20260724-pr-gate-auto-artifact/) | PR Gate：标题定类型 + 变更文件自动校验 Repro/Spec |
+| [`REQ-20260722-mask-handle`](./REQ-20260722-mask-handle/) | `registerPageAgentTool` 返回 `{ showMask, hideMask }` |
 | [`REQ-20260722-console-layout-landmark`](./REQ-20260722-console-layout-landmark/) | `A11yRoleRule.name` + 云控制台 ti-app-layout landmark |
 | [`REQ-20260721-remove-set-navigator`](./REQ-20260721-remove-set-navigator/) | 移除 setNavigator / routeConfig |
 

--- a/packages/next-sdk/specs/REQ-20260729-user-do-action/design.md
+++ b/packages/next-sdk/specs/REQ-20260729-user-do-action/design.md
@@ -1,0 +1,81 @@
+# Design：Page Agent 用户手动操作事件
+
+## 方案概述
+
+在既有 `setupPageAgentToolEventBridge` 中增加 `handleUserDoAction`：于 `window` 捕获阶段监听 `click`；当 mask 可见且为 trusted 点击时，用 `actionContext.getRefMap()` 反查包含 `ev.target` 的 ref 根节点，向 `window` 派发 `page-agent-user-do-action` 自定义事件。生命周期与 tool-call / chat-end 监听共用同一 cleanup。
+
+## 涉及模块 / 文件
+
+- `packages/next-sdk/page-tools/page-agent-tool-event.ts`：常量、`handleUserDoAction`、监听注册与 cleanup。
+- `packages/next-sdk/page-tools/page-agent-tool.ts`：向 `setupPageAgentToolEventBridge` 传入 `actionContext`（第三个参数）。
+
+## 核心数据结构 / 类型定义
+
+```typescript
+export const PAGE_AGENT_USER_DO_ACTION_EVENT = 'page-agent-user-do-action'
+
+export type PageAgentUserDoActionEventDetail = {
+  /** 当前仅支持 'click'，预留其它用户操作类型 */
+  action: 'click'
+  /** refMap 中命中 ev.target 的根 DOM 元素 */
+  dom: HTMLElement
+}
+```
+
+## 依赖变更
+
+- 无新 npm 依赖。
+- `setupPageAgentToolEventBridge` 签名新增第三参 `actionContext: ActionContext`（仅内部调用，不对外 breaking）。
+
+## API / 行为变更
+
+| 符号或行为                                          | 变更类型     | 说明                                            |
+| --------------------------------------------------- | ------------ | ----------------------------------------------- |
+| `PAGE_AGENT_USER_DO_ACTION_EVENT`                   | 新增         | 模块内已导出；包入口 `index.ts` 待补导出        |
+| `PageAgentUserDoActionEventDetail`                  | 新增（类型） | 模块内待显式导出；包入口待补                    |
+| `window` `click` 捕获监听                           | 新增         | 随 `registerPageAgentTool` 挂载，cleanup 时移除 |
+| `setupPageAgentToolEventBridge(..., actionContext)` | 修改         | 新增第三参，用于 `getRefMap()`                  |
+
+## 数据流 / 时序
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Window
+  participant Bridge as setupPageAgentToolEventBridge
+  participant RefMap as actionContext.getRefMap
+  participant Host as 宿主 listener
+
+  User->>Window: trusted click（capture）
+  Window->>Bridge: handleUserDoAction(ev)
+  Bridge->>Bridge: isTrusted && mask.shown?
+  Bridge->>RefMap: getRefMap()
+  RefMap-->>Bridge: Map index → HTMLElement
+  Bridge->>Bridge: find el where el.contains(target)
+  alt 命中 ref 根节点
+    Bridge->>Window: dispatch page-agent-user-do-action
+    Window->>Host: CustomEvent detail { action, dom }
+  end
+```
+
+## 触发条件（决策表）
+
+| isTrusted | mask.shown | target ∈ refMap 子树 | 是否派发 |
+| --------- | ---------- | -------------------- | -------- |
+| false     | \*         | \*                   | 否       |
+| true      | false      | \*                   | 否       |
+| true      | true       | 否                   | 否       |
+| true      | true       | 是                   | 是       |
+
+ref 反查：`Array.from(refMap.values()).find(el => el.contains(target))`，取第一个命中项作为 `detail.dom`。
+
+## 风险与兼容
+
+- **捕获阶段**：不影响现有 bubble 阶段业务点击；仅只读 refMap，不 `preventDefault`。
+- **refMap 时效**：依赖最近一次工具调用时的 ref 快照；mask 展示但 refMap 为空或点击在外部时不派发，属预期。
+- **向后兼容**：纯新增 window 事件，未监听方无感知；`setupPageAgentToolEventBridge` 第三参为内部接线，外部无 API 变更。
+
+## 备选方案（若有）
+
+- **在 SimulatorMask 层监听**：与 refMap 解耦困难，未采用。
+- **bubble 阶段监听**：可能晚于部分 stopPropagation 场景，采用 capture 更稳妥。

--- a/packages/next-sdk/specs/REQ-20260729-user-do-action/requirements.md
+++ b/packages/next-sdk/specs/REQ-20260729-user-do-action/requirements.md
@@ -1,0 +1,67 @@
+# Spec：Page Agent 用户手动操作事件（page-agent-user-do-action）
+
+## 元信息
+
+- 状态：已交付（代码已实现，Spec 事后补建）
+- 主责包：`packages/next-sdk`
+- 关联 Issue：（口头 / 联调需求，无强制 Issue）
+
+## 背景
+
+`registerPageAgentTool` 在 Agent 执行期间会展示 SimulatorMask，引导用户观察 AI 操作。此时用户仍可能手动点击页面（例如在遮罩展示期间介入）。宿主（如 WXT 扩展、Remoter UI）需要感知这类**真实用户点击**，以便同步状态、打断 Agent 或做埋点，但此前事件桥仅覆盖 `page-agent-tool-call` / `page-agent-tool-result` / `page-agent-chat-end`，缺少用户侧操作通知。
+
+## 领域术语表
+
+- **refMap**：page-agent-tool 最近一次工具调用解析出的 index → DOM 元素映射，由 `ActionContext.getRefMap()` 提供。
+- **trusted 事件**：浏览器 `MouseEvent.isTrusted === true`，表示用户真实触发，非脚本 `dispatchEvent` 合成。
+
+## 目标用户 / 场景
+
+- 扩展或聊天 UI 在 mask 展示期间监听用户点击 refMap 内元素，与 Agent 工具调用区分。
+- 联调方通过 `window.addEventListener('page-agent-user-do-action', …)` 接入，无需改 page-agent-tool 内部。
+
+## 参考资料 / 上下文
+
+- `packages/next-sdk/page-tools/page-agent-tool-event.ts`：`setupPageAgentToolEventBridge`
+- `packages/next-sdk/page-tools/page-agent-tool.ts`：注册工具时挂载事件桥
+- 既有事件常量：`PAGE_AGENT_TOOL_CALL_EVENT` 等（同文件）
+
+## 范围
+
+### In Scope
+
+- 新增事件常量 `PAGE_AGENT_USER_DO_ACTION_EVENT`（值 `'page-agent-user-do-action'`）。
+- 在 `setupPageAgentToolEventBridge` 中监听 `window` 捕获阶段 `click`。
+- 满足条件时向 `window` 派发 `CustomEvent`，`detail` 含 `action: 'click'` 与 refMap 命中的 DOM 根节点 `dom`。
+- 触发条件：`ev.isTrusted` 且 `pageController.mask.shown === true`，且点击目标落在当前 `refMap` 某元素子树内。
+- 与既有事件桥共用 `__nextSdkPageAgentToolEventCleanup` 卸载逻辑。
+
+### Out of Scope
+
+- 除 `click` 外的用户操作类型（键盘、滚动等；`detail.action` 预留扩展）。
+- mask 未展示时的用户点击通知。
+- 脚本合成的非 trusted 点击。
+- 宿主侧具体消费逻辑（各包按需接入）。
+
+## 用户故事与验收标准
+
+1. 作为集成方，我希望在 Agent mask 展示期间感知用户真实点击 ref 元素，以便区分「用户介入」与「Agent 工具调用」。
+   - 验收：mask 已 `show`、refMap 含元素 A；用户对 A 内子节点 trusted 点击 → 收到 `page-agent-user-do-action`，`detail.action === 'click'`，`detail.dom === A`。
+2. 作为集成方，我不希望在 mask 隐藏或点击落在 refMap 外时收到误报。
+   - 验收：mask 未展示时不派发；点击不在任何 refMap 元素 `contains` 范围内时不派发。
+3. 作为集成方，我不希望 Agent 或测试脚本合成的点击触发该事件。
+   - 验收：`isTrusted === false` 的 click 不派发。
+4. 作为维护者，我希望重复 `registerPageAgentTool` 不会叠加多个 click 监听。
+   - 验收：再次注册前先执行 cleanup，仅保留一套监听。
+
+## 非功能要求
+
+- 捕获阶段监听，尽量在目标处理前完成 ref 解析；不阻止事件默认传播。
+- 与现有三个 page-agent  window 事件命名风格一致。
+
+## 完成定义
+
+- [x] `design.md` / `tasks.md` 已齐
+- [ ] 自动化测试已实现（见 `tasks.md` Task 4，待补）
+- [ ] 包入口导出 `PAGE_AGENT_USER_DO_ACTION_EVENT` 与 `PageAgentUserDoActionEventDetail`（见 `tasks.md` Task 3，待补）
+- [x] `pnpm -F @opentiny/next-sdk test` 无回归

--- a/packages/next-sdk/specs/REQ-20260729-user-do-action/tasks.md
+++ b/packages/next-sdk/specs/REQ-20260729-user-do-action/tasks.md
@@ -1,0 +1,35 @@
+# Tasks：Page Agent 用户手动操作事件
+
+## 任务列表
+
+- [x] Task 1: 实现事件常量与 `handleUserDoAction`
+  - 输入（依赖）：`ActionContext.getRefMap()`、`pageController.mask.shown`
+  - 产物：`packages/next-sdk/page-tools/page-agent-tool-event.ts`
+    - 导出 `PAGE_AGENT_USER_DO_ACTION_EVENT`
+    - 捕获阶段 `click` 监听 + cleanup
+    - 满足条件时派发 `{ action: 'click', dom: targetParent }`
+- [x] Task 2: `registerPageAgentTool` 接线 `actionContext`
+  - 产物：`packages/next-sdk/page-tools/page-agent-tool.ts` 调用 `setupPageAgentToolEventBridge(..., actionContext)`
+- [ ] Task 3: 包入口与类型导出
+  - 产物：
+    - `page-agent-tool-event.ts` 显式导出 `PageAgentUserDoActionEventDetail`
+    - `packages/next-sdk/index.ts` 导出常量与类型
+  - 说明：实现已完成核心行为，公开导出待补，便于宿主 `import { PAGE_AGENT_USER_DO_ACTION_EVENT } from '@opentiny/next-sdk'`
+- [ ] Task 4: 自动化测试
+  - [ ] 测试：`packages/next-sdk/test/page-tools/page-agent-tool.test.ts`（或独立 event 测试文件）
+  - 场景（须含中文 **`复现：`**）：
+    - mask 已 show + refMap 命中 → 派发 `page-agent-user-do-action`
+    - mask 未 show / 非 trusted / 点击在 refMap 外 → 不派发
+- [ ] Task 5: 用户文档 / Skill（可选）
+  - 产物：`docs/webmcp-sdk/page-agent-tool.md`、`skills/page-agent/SKILL.md` 补充事件说明
+
+## 依赖顺序
+
+1 → 2 →（3、4 可并行）→ 5
+
+## 验收命令
+
+```bash
+pnpm -F @opentiny/next-sdk test
+pnpm -F @opentiny/next-sdk build
+```


### PR DESCRIPTION
## Summary

每次用户点击事件，向window发送一个 'page-agent-user-do-action' 事件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for detecting trusted user clicks on available page actions while the tool interaction mask is displayed.
  * Added a new `page-agent-user-do-action` event that reports the clicked DOM root during masked tool execution.
* **Bug Fixes**
  * Improved interaction pass-through behavior by keeping pointer handling disabled while the mask is active.
  * Removed the waiting cursor from the interaction overlay.
* **Chores**
  * Improved the web build workflow by building the root package before the webmcp CLI workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->