### PR TITLE
feat: 为Remoter组件添加语音输入属性

### DIFF
--- a/docs/remoter/basic.md
+++ b/docs/remoter/basic.md
@@ -146,6 +146,7 @@ type UnifiedModelConfig = ICustomAgentModelProviderLlmConfig & {
 - `inBrowserExt` 设置组件运行于普通页面还是浏览器扩展，默认值为 `false`
 - `genUiAble` 双向绑定是否启用生成式 UI 渲染，默认值为 `false`。输入框旁的「生成式 UI」开关是否显示由**当前模型配置**决定：仅当配置中同时包含 `baseURL` 和 `genuiUrl` 时才会显示
 - `genUiComponents` 生成式 UI 已内置一批组件；如需支持额外组件，可通过该属性导入，例如：`shallowReactive({ TinyUser, TinyAlert })`
+- `allowSpeech` 启用语言输入模式。
 
 ## 二、事件
 

--- a/docs/remoter/basic.md
+++ b/docs/remoter/basic.md
@@ -146,7 +146,7 @@ type UnifiedModelConfig = ICustomAgentModelProviderLlmConfig & {
 - `inBrowserExt` 设置组件运行于普通页面还是浏览器扩展，默认值为 `false`
 - `genUiAble` 双向绑定是否启用生成式 UI 渲染，默认值为 `false`。输入框旁的「生成式 UI」开关是否显示由**当前模型配置**决定：仅当配置中同时包含 `baseURL` 和 `genuiUrl` 时才会显示
 - `genUiComponents` 生成式 UI 已内置一批组件；如需支持额外组件，可通过该属性导入，例如：`shallowReactive({ TinyUser, TinyAlert })`
-- `allowSpeech` 启用语言输入模式。
+- `allowSpeech` 启用语言输入模式，默认值为 `false`
 
 ## 二、事件
 

--- a/packages/next-remoter/src/components/TinyRobotChat.vue
+++ b/packages/next-remoter/src/components/TinyRobotChat.vue
@@ -74,6 +74,9 @@
                 :multiple="true" @select="onFilesSelected" />
             </div>
           </template>
+          <template #footer-right>
+            <VoiceButton v-if="allowSpeech" />
+          </template>
         </tr-sender>
 
         <!-- 插件面板 -->
@@ -107,7 +110,8 @@ import {
   TrMcpServerPicker,
   TrHistory,
   TrAttachments,
-  TrUploadButton
+  TrUploadButton,
+  VoiceButton
 } from '@opentiny/tiny-robot'
 
 import type { PluginInfo, MarketCategoryOption } from '@opentiny/tiny-robot'
@@ -266,6 +270,11 @@ const props = defineProps({
   pillItems: {
     type: Array,
     default: undefined
+  },
+  /** 支持语音输入功能 */
+  allowSpeech: {
+    type: Boolean,
+    default: false
   }
 })
 


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)

`allowSpeech` 启用语言输入模式，默认值为 `false`

> PR Gate 根据**约定式标题**判断类型（`fix` / `feat` / `docs` / …），并从本 PR **变更文件**自动校验：Bug 须有复现测试，Feature 须同时有 Spec 与测试。
> 标签为兜底（与 auto-label 一致：`bug` / `enhancement` 等）。琐碎 Feature 可打 `skip-spec`（仅豁免 Spec）；应急打 `gate-bypass`。

## Summary

-

## What is the current behavior?

-

## What is the new behavior?

-

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Other information

（可选。Issue 请用 GitHub 原生关联，无需手填路径。）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional voice input to TinyRobotChat.
  * When enabled, users can send messages using a voice input button.
  * Voice input is disabled by default and can be enabled through the `allowSpeech` setting.
* **Documentation**
  * Documented the new `allowSpeech` setting and its default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->