### PR TITLE
feat(next-sdk): separate development tools into a new 'dev' entry point

### DIFF
--- a/packages/doc-ai/src/main.ts
+++ b/packages/doc-ai/src/main.ts
@@ -2,11 +2,8 @@ import { createApp } from 'vue'
 import router from './router'
 import App from './App.vue'
 import './style.css'
-import {
-  enableInspectAssist,
-  initializeBuiltinWebMCP,
-  registerPageAgentTool,
-} from '@opentiny/next-sdk'
+import { initializeBuiltinWebMCP, registerPageAgentTool } from '@opentiny/next-sdk'
+import { enableInspectAssist } from '@opentiny/next-sdk/dev'
 
 initializeBuiltinWebMCP()
 // 单页应用工具注册一次即可

--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-remoter",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/tiny-robot-remoter.html",
   "repository": {

--- a/packages/next-sdk/AGENTS.md
+++ b/packages/next-sdk/AGENTS.md
@@ -37,7 +37,7 @@
 | `remoter/` | `createRemoter`、`QrCode` |
 | `skills/index.ts` | **运行时**业务 Skill 工具（给终端用户 Agent），不是编码用 SKILL.md |
 | `skills/page-agent/` | **编码** Agent Skill（本包 page-agent） |
-| `runtime.ts` / `core.ts` / `index.ts` | 入口差异见下 |
+| `runtime.ts` / `core.ts` / `dev.ts` / `index.ts` | 入口差异见下 |
 | `specs/` | Feature Spec 实例 |
 | `test/` | Vitest 可执行测试 |
 
@@ -45,6 +45,7 @@
 
 - `index.ts`：完整导出（含 page-agent、remoter、skills API、polyfill）
 - `core.ts`：无 DOM 精简（Agent / `initializeBuiltinWebMCP` 等）
+- `dev.ts`：本地开发辅助（如 `dom-inspect` / Inspect Assist），路径 `@opentiny/next-sdk/dev`
 - `runtime.ts`：IIFE/CDN，挂 page-agent 相关 API，**不**自动 register
 
 ## Page Agent API（摘要）

--- a/packages/next-sdk/dev.ts
+++ b/packages/next-sdk/dev.ts
@@ -1,0 +1,18 @@
+// 本地开发相关能力入口（勿在生产路径默认引入）
+// 例如 Inspect Assist（dom-inspect）等开发辅助工具
+
+export {
+  enableInspectAssist,
+  disableInspectAssist,
+  buildElementMeta,
+  formatElementMetaText,
+  truncateHtml,
+  buildDomPath,
+} from './dom-inspect'
+export type {
+  InspectAssistOptions,
+  InspectAssistHandle,
+  ElementMeta,
+  ElementPosition,
+  ElementAttribute,
+} from './dom-inspect'

--- a/packages/next-sdk/index.ts
+++ b/packages/next-sdk/index.ts
@@ -113,20 +113,3 @@ export type {
   VNode,
   RefMap
 } from './page-tools/a11y/types'
-
-// Inspect Assist：点选区域复制 Cursor 元素卡片，辅助定位改样式/逻辑
-export {
-  enableInspectAssist,
-  disableInspectAssist,
-  buildElementMeta,
-  formatElementMetaText,
-  truncateHtml,
-  buildDomPath,
-} from './dom-inspect'
-export type {
-  InspectAssistOptions,
-  InspectAssistHandle,
-  ElementMeta,
-  ElementPosition,
-  ElementAttribute,
-} from './dom-inspect'

--- a/packages/next-sdk/package.json
+++ b/packages/next-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-sdk",
-  "version": "0.4.5",
+  "version": "0.4.5-alpha.1",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/",
   "repository": {

--- a/packages/next-sdk/package.json
+++ b/packages/next-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-sdk",
-  "version": "0.4.5-alpha.1",
+  "version": "0.4.6",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/",
   "repository": {

--- a/packages/next-sdk/package.json
+++ b/packages/next-sdk/package.json
@@ -35,6 +35,10 @@
     "./core": {
       "import": "./core.ts",
       "types": "./core.ts"
+    },
+    "./dev": {
+      "import": "./dev.ts",
+      "types": "./dev.ts"
     }
   },
   "description": "A frontend intelligent application development toolkit designed to simplify WebAgent integration and usage, supporting multiple programming languages and frontend frameworks to help developers rapidly implement intelligent features",
@@ -88,6 +92,10 @@
       "./core": {
         "import": "./dist/core.js",
         "types": "./dist/core.d.ts"
+      },
+      "./dev": {
+        "import": "./dist/dev.js",
+        "types": "./dist/dev.d.ts"
       }
     }
   }

--- a/packages/next-sdk/specs/README.md
+++ b/packages/next-sdk/specs/README.md
@@ -20,6 +20,7 @@
 
 | Spec | 说明 |
 |---|---|
+| [`REQ-20260807-dev-entry`](./REQ-20260807-dev-entry/) | 新增 `dev` 入口：将 `dom-inspect` 等本地开发能力从主入口拆出 |
 | [`REQ-20260729-user-do-action`](./REQ-20260729-user-do-action/) | mask 展示期间用户 trusted 点击 → `page-agent-user-do-action` 事件 |
 | [`REQ-20260727-dom-inspect`](./REQ-20260727-dom-inspect/) | Inspect Assist（`enableInspectAssist`）：点选复制 Cursor 元素卡片，辅助改样式/逻辑 |
 | [`REQ-20260724-pr-gate-auto-artifact`](./REQ-20260724-pr-gate-auto-artifact/) | PR Gate：标题定类型 + 变更文件自动校验 Repro/Spec |

--- a/packages/next-sdk/specs/REQ-20260807-dev-entry/design.md
+++ b/packages/next-sdk/specs/REQ-20260807-dev-entry/design.md
@@ -1,0 +1,68 @@
+# Spec：dev 入口拆分设计
+
+## 方案概述
+
+新增与 `index` / `core` 并列的 Vite lib 入口 `dev`，由 `dev.ts` 再导出 `./dom-inspect`。主入口 `index.ts` 删除 Inspect Assist 导出。`package.json` 的 `exports` 与 `publishConfig.exports` 同步增加 `./dev`。仓内唯一已知消费方 `doc-ai` 改为从 `@opentiny/next-sdk/dev` 导入。
+
+## 涉及模块 / 文件
+
+- `packages/next-sdk/dev.ts`（新增）
+- `packages/next-sdk/vite.config.ts`
+- `packages/next-sdk/package.json`
+- `packages/next-sdk/index.ts`
+- `packages/next-sdk/AGENTS.md`
+- `packages/next-sdk/specs/README.md`
+- `packages/doc-ai/src/main.ts`
+- `packages/next-sdk/test/dev-entry.test.ts`（新增）
+
+## 核心数据结构 / 类型定义
+
+无新类型；`dev.ts` 对 `dom-inspect` 做透明再导出：
+
+```typescript
+export {
+  enableInspectAssist,
+  disableInspectAssist,
+  buildElementMeta,
+  formatElementMetaText,
+  truncateHtml,
+  buildDomPath,
+} from './dom-inspect'
+export type {
+  InspectAssistOptions,
+  InspectAssistHandle,
+  ElementMeta,
+  ElementPosition,
+  ElementAttribute,
+} from './dom-inspect'
+```
+
+## 依赖变更
+
+无新 npm 依赖。
+
+## API / 行为变更
+
+| 符号或行为 | 变更类型 | 说明 |
+|---|---|---|
+| `@opentiny/next-sdk` → Inspect Assist 导出 | 废弃/移除 | 主入口不再导出 |
+| `@opentiny/next-sdk/dev` | 新增 | 开发态入口，导出 Inspect Assist |
+| `dist/dev.js` / `dist/dev.d.ts` | 新增 | 构建产物 |
+
+## 数据流 / 时序（可选）
+
+```mermaid
+flowchart LR
+  A[消费者] -->|生产/通用| B["@opentiny/next-sdk"]
+  A -->|本地开发工具| C["@opentiny/next-sdk/dev"]
+  C --> D[dom-inspect]
+```
+
+## 风险与兼容
+
+- **破坏性**：原先从主入口导入 `enableInspectAssist` 的外部消费者需改路径；仓内已同步 `doc-ai`。
+- 单元测试仍可直接 `from '../dom-inspect'`，不受入口拆分影响。
+
+## 备选方案（若有）
+
+- 仅文档约定「勿在生产使用」但仍挂在主入口：无法真正解耦，否决。

--- a/packages/next-sdk/specs/REQ-20260807-dev-entry/requirements.md
+++ b/packages/next-sdk/specs/REQ-20260807-dev-entry/requirements.md
@@ -1,0 +1,66 @@
+# Spec：dev 入口拆分（本地开发能力）
+
+## 元信息
+
+- 状态：已交付
+- 主责包：`packages/next-sdk`
+- 协作包：`packages/doc-ai`（示例消费方）
+- 关联 Issue：
+
+## 背景
+
+`dom-inspect`（Inspect Assist）等能力仅用于本地开发辅助，不应随主包 `@opentiny/next-sdk` 默认入口打入生产消费路径。需要新增独立入口 `dev.ts`，将开发态工具从 `index.ts` 拆出，减小主包心智负担与潜在体积耦合。
+
+## 领域术语表
+
+- **dev 入口**：`@opentiny/next-sdk/dev`，专放本地开发相关导出（如 `dom-inspect`）
+- **主入口**：`@opentiny/next-sdk`（`index.ts`），面向生产与通用 SDK 能力
+
+## 目标用户 / 场景
+
+本地开发者在 playground / 文档站等工程中按需 `import { enableInspectAssist } from '@opentiny/next-sdk/dev'`。
+
+## 参考资料 / 上下文
+
+- `packages/next-sdk/index.ts` / `core.ts` / `vite.config.ts` / `package.json`
+- `packages/next-sdk/dom-inspect/`
+- `packages/next-sdk/specs/REQ-20260727-dom-inspect/`
+- `packages/doc-ai/src/main.ts`
+
+## 范围
+
+### In Scope
+
+- 新增 `dev.ts` 入口，导出 `dom-inspect` 相关 API
+- Vite lib 多入口增加 `dev`
+- `package.json` / `publishConfig.exports` 增加 `./dev`
+- 从 `index.ts` 移除 `dom-inspect` 导出
+- 更新 `doc-ai` 等仓内消费方导入路径
+- 更新包 `AGENTS.md` 入口差异说明
+- 自动化测试锁定入口契约
+
+### Out of Scope
+
+- 改动 `dom-inspect` 运行时行为
+- 将 `dev` 入口做成 CDN/IIFE runtime 包
+
+## 用户故事与验收标准
+
+1. 作为 SDK 维护者，我希望主入口不再导出 Inspect Assist，以便生产消费者不会误用开发工具。
+   - 验收：`index.ts` 无 `dom-inspect` / `enableInspectAssist` 导出；测试断言主入口不包含这些符号。
+2. 作为本地开发者，我希望通过 `@opentiny/next-sdk/dev` 使用 `enableInspectAssist` 等 API。
+   - 验收：`dev.ts` 导出与原先主入口一致的 Inspect Assist 符号；`doc-ai` 开发态导入路径已切换。
+3. 作为发布流水线，我希望构建产物包含 `dist/dev.js` 与类型声明，且 exports 可解析。
+   - 验收：Vite 多入口含 `dev`；`package.json` exports 含 `./dev`。
+
+## 非功能要求
+
+- 破坏性变更：从 `@opentiny/next-sdk` 直接导入 Inspect Assist 将失败，需改为 `/dev` 子路径
+- 不改变 `dom-inspect` 功能语义
+
+## 完成定义
+
+- [x] `design.md` / `tasks.md` 已齐
+- [x] 对应自动化测试已在 `tasks.md` 列出并实现
+- [x] 包 `AGENTS.md` 入口差异已更新
+- [x] `doc-ai` 导入路径已更新

--- a/packages/next-sdk/specs/REQ-20260807-dev-entry/tasks.md
+++ b/packages/next-sdk/specs/REQ-20260807-dev-entry/tasks.md
@@ -1,0 +1,29 @@
+# Spec：dev 入口拆分任务
+
+## 任务列表
+
+- [x] Task 1: 新增 `dev.ts` 再导出 `dom-inspect`
+  - 产物：`packages/next-sdk/dev.ts`
+- [x] Task 2: Vite / package.json 注册 `dev` 入口
+  - 产物：`packages/next-sdk/vite.config.ts`、`packages/next-sdk/package.json`
+- [x] Task 3: 从 `index.ts` 移除 Inspect Assist 导出；更新 `doc-ai` 导入
+  - 产物：`packages/next-sdk/index.ts`、`packages/doc-ai/src/main.ts`
+- [x] Task 4: 入口契约测试
+  - [x] 测试：`packages/next-sdk/test/dev-entry.test.ts`
+    - 断言主入口源码不再导出 Inspect Assist
+    - 断言 `dev.ts` 导出关键符号
+    - 断言 `package.json` exports 含 `./dev`
+- [x] Task 5: 更新 `AGENTS.md` 入口差异与 Specs 索引
+  - 产物：`packages/next-sdk/AGENTS.md`、`packages/next-sdk/specs/README.md`
+  - 将 Spec 状态标为已交付
+
+## 依赖顺序
+
+1 → 2 → 3 → 4 → 5
+
+## 验收命令
+
+```bash
+pnpm -F @opentiny/next-sdk test
+pnpm -F @opentiny/next-sdk build
+```

--- a/packages/next-sdk/test/dev-entry.test.ts
+++ b/packages/next-sdk/test/dev-entry.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import * as devEntry from '../dev'
+
+const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+describe('dev 入口契约', () => {
+  it('主入口 index.ts 不再导出 Inspect Assist（dom-inspect）', () => {
+    const indexSrc = readFileSync(join(pkgRoot, 'index.ts'), 'utf8')
+    expect(indexSrc).not.toMatch(/from ['"]\.\/dom-inspect['"]/)
+    expect(indexSrc).not.toContain('enableInspectAssist')
+  })
+
+  it('dev.ts 导出本地开发相关的 Inspect Assist API', () => {
+    expect(typeof devEntry.enableInspectAssist).toBe('function')
+    expect(typeof devEntry.disableInspectAssist).toBe('function')
+    expect(typeof devEntry.buildElementMeta).toBe('function')
+    expect(typeof devEntry.formatElementMetaText).toBe('function')
+    expect(typeof devEntry.truncateHtml).toBe('function')
+    expect(typeof devEntry.buildDomPath).toBe('function')
+  })
+
+  it('package.json exports 与 Vite 构建入口包含 ./dev', () => {
+    const pkg = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8')) as {
+      exports: Record<string, unknown>
+      publishConfig: { exports: Record<string, unknown> }
+    }
+    expect(pkg.exports).toHaveProperty('./dev')
+    expect(pkg.publishConfig.exports).toHaveProperty('./dev')
+
+    const viteSrc = readFileSync(join(pkgRoot, 'vite.config.ts'), 'utf8')
+    expect(viteSrc).toMatch(/dev:\s*['"]dev\.ts['"]/)
+  })
+})

--- a/packages/next-sdk/test/dev-entry.test.ts
+++ b/packages/next-sdk/test/dev-entry.test.ts
@@ -2,33 +2,54 @@ import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import * as mainEntry from '../index'
 import * as devEntry from '../dev'
 
 const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
 
+/** 从主入口迁到 @opentiny/next-sdk/dev 的运行时符号 */
+const DEV_RUNTIME_SYMBOLS = [
+  'enableInspectAssist',
+  'disableInspectAssist',
+  'buildElementMeta',
+  'formatElementMetaText',
+  'truncateHtml',
+  'buildDomPath',
+] as const
+
 describe('dev 入口契约', () => {
-  it('主入口 index.ts 不再导出 Inspect Assist（dom-inspect）', () => {
+  it('主入口有效导出不含已迁出的 Inspect Assist 运行时符号', () => {
     const indexSrc = readFileSync(join(pkgRoot, 'index.ts'), 'utf8')
     expect(indexSrc).not.toMatch(/from ['"]\.\/dom-inspect['"]/)
-    expect(indexSrc).not.toContain('enableInspectAssist')
+
+    for (const symbol of DEV_RUNTIME_SYMBOLS) {
+      expect(indexSrc).not.toContain(symbol)
+      expect(mainEntry).not.toHaveProperty(symbol)
+      expect((mainEntry as Record<string, unknown>)[symbol]).toBeUndefined()
+    }
   })
 
   it('dev.ts 导出本地开发相关的 Inspect Assist API', () => {
-    expect(typeof devEntry.enableInspectAssist).toBe('function')
-    expect(typeof devEntry.disableInspectAssist).toBe('function')
-    expect(typeof devEntry.buildElementMeta).toBe('function')
-    expect(typeof devEntry.formatElementMetaText).toBe('function')
-    expect(typeof devEntry.truncateHtml).toBe('function')
-    expect(typeof devEntry.buildDomPath).toBe('function')
+    for (const symbol of DEV_RUNTIME_SYMBOLS) {
+      expect(devEntry).toHaveProperty(symbol)
+      expect(typeof (devEntry as Record<string, unknown>)[symbol]).toBe('function')
+    }
   })
 
-  it('package.json exports 与 Vite 构建入口包含 ./dev', () => {
+  it('package.json exports 精确映射 ./dev 源码与发布产物', () => {
     const pkg = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8')) as {
       exports: Record<string, unknown>
       publishConfig: { exports: Record<string, unknown> }
     }
-    expect(pkg.exports).toHaveProperty('./dev')
-    expect(pkg.publishConfig.exports).toHaveProperty('./dev')
+
+    expect(pkg.exports['./dev']).toEqual({
+      import: './dev.ts',
+      types: './dev.ts',
+    })
+    expect(pkg.publishConfig.exports['./dev']).toEqual({
+      import: './dist/dev.js',
+      types: './dist/dev.d.ts',
+    })
 
     const viteSrc = readFileSync(join(pkgRoot, 'vite.config.ts'), 'utf8')
     expect(viteSrc).toMatch(/dev:\s*['"]dev\.ts['"]/)

--- a/packages/next-sdk/vite.config.ts
+++ b/packages/next-sdk/vite.config.ts
@@ -37,7 +37,9 @@ export default defineConfig(() => {
       lib: {
         entry: {
           index: 'index.ts',
-          core: 'core.ts'
+          core: 'core.ts',
+          // 本地开发相关能力（如 dom-inspect），勿与主入口混用
+          dev: 'dev.ts'
         },
         name: 'NEXT-SDK',
         formats: ['es'],


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)

> PR Gate 根据**约定式标题**判断类型（`fix` / `feat` / `docs` / …），并从本 PR **变更文件**自动校验：Bug 须有复现测试，Feature 须同时有 Spec 与测试。
> 标签为兜底（与 auto-label 一致：`bug` / `enhancement` 等）。琐碎 Feature 可打 `skip-spec`（仅豁免 Spec）；应急打 `gate-bypass`。

## Summary

-

## What is the current behavior?

-

## What is the new behavior?

-

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Other information

（可选。Issue 请用 GitHub 原生关联，无需手填路径。）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated `@opentiny/next-sdk/dev` entry point for Inspect Assist and related development-only APIs.
  * Development builds and package exports now include the new entry point.

* **Breaking Changes**
  * Inspect Assist APIs are no longer exported from the main SDK entry point. Update imports to use `@opentiny/next-sdk/dev`.

* **Tests**
  * Added coverage to verify the new entry point and export configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->